### PR TITLE
Emergency fixes based on BotBuilder 3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [*1.1.1*] - <*2017-05-08*>
+
+### Changed
+
+* Adapt to changes to BotBuilder's IMessage interface in BotBuilder 3.8
+
+### Fixes
+
+* Bug fixes in msteams-app.css
 
 ## [*1.1.0*] - <*2017-05-02*>
 
@@ -18,7 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * New Teams .d.ts file (0.4 schema)
 * Updates to npm packages
 * Use of `entityId` instead of query string parameter for tab value
-* + lots of more smaller fixes
+* \+ lots of more smaller fixes
 
 ## [*1.0.2*] - <*2017-03-28*>
 

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -377,8 +377,8 @@ exports.GeneratorTeamsTab = GeneratorTeamsTab;
 
 module.exports = {
 	"name": "generator-teams",
-	"version": "1.1.0",
-	"description": "Yeoman generator for Microsoft Teams apps",
+	"version": "1.1.1",
+	"description": "Yeoman generator for Microsoft Teams Apps",
 	"main": "generators/app/index.js",
 	"scripts": {},
 	"files": [

--- a/generators/app/templates/src/app/web/assets/css/msteams-app.css
+++ b/generators/app/templates/src/app/web/assets/css/msteams-app.css
@@ -1,5 +1,8 @@
 @charset "UTF-8";
 
+html {
+  font-size: 10px;
+}
 body {
   font-family:  "Segoe UI", "Helvetica Neue", Helvetica, Arial, sans-serif !important;
   font-size: 1.4rem;
@@ -12,14 +15,18 @@ a:hover, a:focus {
   text-decoration: underline;
   outline: none;
 }
-
+* {
+    box-sizing: border-box;
+    -webkit-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+}
 /* Form controls */
 .form-field-title:first-of-type {
   margin-top: 0;
 }
 .form-field-title {
   display: flex;
-  margin: 1rem 0 .3rem;
+  margin: .7rem 0 .3rem;
 }
 .form-control:focus {
   border-bottom-color: #5558af;
@@ -36,7 +43,6 @@ a:hover, a:focus {
   box-shadow: none;
   display: block;
   width: 100%;
-  height: 34px;
   padding: 6px 12px;
   font-family: inherit;
   font-size: 14px;

--- a/generators/bot/templates/src/app/{botName}.ts
+++ b/generators/bot/templates/src/app/{botName}.ts
@@ -70,10 +70,12 @@ export class <%= botName %> {
      * @param message builder.IMessage
      */
     private static extractTextFromMessage(message: builder.IMessage): string {
-        var s = message.text;
-        message.entities.forEach((ent: any) => {
-            s = s.replace(ent.text, '');
-        });
+        var s = (message.text) ? message.text : '';
+        if (message.entities) {
+            message.entities.forEach((ent: any) => {
+                s = s.replace(ent.text, '');
+            })            
+        }
         return s.trim();
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "generator-teams",
-  "version": "1.1.0",
-  "description": "Yeoman generator for Microsoft Teams apps",
+  "version": "1.1.1",
+  "description": "Yeoman generator for Microsoft Teams Apps",
   "main": "generators/app/index.js",
   "scripts": {},
   "files": [

--- a/src/app/templates/src/app/web/assets/css/msteams-app.css
+++ b/src/app/templates/src/app/web/assets/css/msteams-app.css
@@ -1,5 +1,8 @@
 @charset "UTF-8";
 
+html {
+  font-size: 10px;
+}
 body {
   font-family:  "Segoe UI", "Helvetica Neue", Helvetica, Arial, sans-serif !important;
   font-size: 1.4rem;
@@ -12,14 +15,18 @@ a:hover, a:focus {
   text-decoration: underline;
   outline: none;
 }
-
+* {
+    box-sizing: border-box;
+    -webkit-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+}
 /* Form controls */
 .form-field-title:first-of-type {
   margin-top: 0;
 }
 .form-field-title {
   display: flex;
-  margin: 1rem 0 .3rem;
+  margin: .7rem 0 .3rem;
 }
 .form-control:focus {
   border-bottom-color: #5558af;
@@ -36,7 +43,6 @@ a:hover, a:focus {
   box-shadow: none;
   display: block;
   width: 100%;
-  height: 34px;
   padding: 6px 12px;
   font-family: inherit;
   font-size: 14px;

--- a/src/bot/templates/src/app/{botName}.ts
+++ b/src/bot/templates/src/app/{botName}.ts
@@ -70,10 +70,12 @@ export class <%= botName %> {
      * @param message builder.IMessage
      */
     private static extractTextFromMessage(message: builder.IMessage): string {
-        var s = message.text;
-        message.entities.forEach((ent: any) => {
-            s = s.replace(ent.text, '');
-        });
+        var s = (message.text) ? message.text : '';
+        if (message.entities) {
+            message.entities.forEach((ent: any) => {
+                s = s.replace(ent.text, '');
+            })            
+        }
         return s.trim();
     }
 }


### PR DESCRIPTION
The day before I was going to demo the generator, I was showing off how easy it was and it broke! There was a compilation error in the bot code. 

Basically the IMessage interface changed - some of the parameters are now optional instead of required, and that led to the possibility that the .text and .entities member variables were null. So that's now protected against.

The other change was some minor tweaks to msteams-app.css. Last but not least I updated the version number to 1.1.1.

I know it's last minute but if this looks good can you please merge and push to npmjs so everyone can run the latest and greatest? Otherwise I have to make everyone manually change package.json in the generated solution and that's clunky.

(It says there are six commits but three are duplicates of each other as the diffs will show.)