### PR TITLE
remove trailing forward slash from the host name answer

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -289,6 +289,7 @@ class GeneratorTeamsTab extends Generator {
                 ]
             }
         ]).then((answers) => {
+            answers.host = answers.host.endsWith('/') ? answers.host.substr(0, answers.host.length - 1) : answers.host;
             this.options.title = answers.name;
             this.options.description = this.description;
             this.options.solutionName = this.options.solutionName || answers.solutionName;

--- a/src/app/GeneratorTeamsTab.ts
+++ b/src/app/GeneratorTeamsTab.ts
@@ -115,6 +115,7 @@ export class GeneratorTeamsTab extends Generator {
                 }
             ]
         ).then((answers: any) => {
+            answers.host= answers.host.endsWith('/') ? answers.host.substr(0, answers.host.length - 1) : answers.host;
             this.options.title = answers.name;
             this.options.description = this.description;
             this.options.solutionName = this.options.solutionName || answers.solutionName;


### PR DESCRIPTION
Hello Team, 

This pull request to remove the trailing forward slash "/" at the end of the host name so the allowed domains value of the manifest file will have a correct value.
in the preview it also would allow the generation of a correct package name net.azurewebsites.subdomain instead of /net.azurewebsites.subdomain

let me know your thoughts :)

Amr