### PR TITLE
Change to "node" strategy for moduleResolution

### DIFF
--- a/generators/app/templates/tsconfig-client.json
+++ b/generators/app/templates/tsconfig-client.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "module": "commonjs",
         "target": "es5",
-        "moduleResolution": "classic",
+        "moduleResolution": "node",
         "noImplicitAny": false,
         "strictNullChecks": true,
         "jsx": "react",

--- a/src/app/templates/tsconfig-client.json
+++ b/src/app/templates/tsconfig-client.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "module": "commonjs",
         "target": "es5",
-        "moduleResolution": "classic",
+        "moduleResolution": "node",
         "noImplicitAny": false,
         "strictNullChecks": true,
         "jsx": "react",


### PR DESCRIPTION
Per the [TypeScript site](https://www.typescriptlang.org/docs/handbook/module-resolution.html), the "classic" strategy is for backward compatibility. 

For packages that integrate their TypeScript declaraions (MSAL for example), the 'classic' strategy does not resolve those declarations.

For packages with  @types-scoped declarations, the 'node' strategy will still work.