### PR TITLE
Change help To Help to be the same as manifest

### DIFF
--- a/src/bot/templates/src/app/{botName}.ts
+++ b/src/bot/templates/src/app/{botName}.ts
@@ -37,7 +37,7 @@ export class <%= botName %> implements IBot {
 		
         // Add dialogs here
         this.universalBot.dialog('/', this.defaultDialog);
-        this.universalBot.dialog('/help', this.helpDialog);
+        this.universalBot.dialog('/Help', this.helpDialog);
  
         // Control messages
         this.universalBot.on('conversationUpdate', this.convUpdateHandler);
@@ -110,8 +110,8 @@ export class <%= botName %> implements IBot {
             session.send('Oh, hello to you as well!');
             session.endDialog();
             return;
-        } else if (text.startsWith('help')) {
-            session.beginDialog('/help');
+        } else if (text.startsWith('Help')) {
+            session.beginDialog('/Help');
             return
         }
         session.endDialog('I\'m terribly sorry, but my master hasn\'t trained me to do anything yet...');    


### PR DESCRIPTION
If you would use the Help which comes with the manifest it would not work as the comment caught was help instead of Help so changed it to Help in the bot.