### PR TITLE
PoC Integration Tests for generated projects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-teams",
-  "version": "2.12.0-preview",
+  "version": "2.12.0-preview3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -130,6 +130,15 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.1.tgz",
       "integrity": "sha512-aK9jxMypeSrhiYofWWBf/T7O+KwaiAHzM4sveCdWPn71lzUSMimRnKzhXDKfKwV1kWoBo2P1aGgaIYGLf9/ljw==",
       "dev": true
+    },
+    "@types/npm-run": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/npm-run/-/npm-run-5.0.0.tgz",
+      "integrity": "sha512-SbRnR2S0/CL9GW5mKng/V9T3uEPFSkGC5a71AcyCnT1ltK/kSv1A0nSO8AYI3FjuE4ep04HPi6eCuXWpnwD5HQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/semver": {
       "version": "6.0.1",
@@ -908,6 +917,17 @@
         "ssri": "^6.0.1",
         "unique-filename": "^1.1.1",
         "y18n": "^4.0.0"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "cache-base": {
@@ -1261,6 +1281,17 @@
         "mkdirp": "^0.5.1",
         "rimraf": "^2.5.4",
         "run-queue": "^1.0.0"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "copy-descriptor": {
@@ -1543,6 +1574,15 @@
           "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
           "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
           "dev": true
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
         }
       }
     },
@@ -2222,8 +2262,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2244,14 +2283,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2266,20 +2303,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2396,8 +2430,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2409,7 +2442,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2424,7 +2456,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2432,14 +2463,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2458,7 +2487,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2539,8 +2567,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2552,7 +2579,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2638,8 +2664,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2675,7 +2700,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2695,7 +2719,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2739,14 +2762,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -3716,6 +3737,14 @@
         "vinyl": "^2.0.1"
       },
       "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
         "through2": {
           "version": "2.0.5",
           "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
@@ -3960,6 +3989,17 @@
         "mkdirp": "^0.5.1",
         "rimraf": "^2.5.4",
         "run-queue": "^1.0.3"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "ms": {
@@ -4131,6 +4171,27 @@
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true
     },
+    "npm-path": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/npm-path/-/npm-path-2.0.4.tgz",
+      "integrity": "sha512-IFsj0R9C7ZdR5cP+ET342q77uSRdtWOlWpih5eC+lu29tIDbNEgDbzgVJ5UFvYHWhxDZ5TFkJafFioO0pPQjCw==",
+      "dev": true,
+      "requires": {
+        "which": "^1.2.10"
+      }
+    },
+    "npm-run": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run/-/npm-run-5.0.1.tgz",
+      "integrity": "sha512-s7FyRpHUgaJfzkRgOnevX8rAWWsv1dofY1XS7hliWCF6LSQh+HtDfBvpigPS1krLvXw+Fi17CYMY8mUtblnyWw==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.0",
+        "npm-path": "^2.0.4",
+        "npm-which": "^3.0.1",
+        "serializerr": "^1.0.3"
+      }
+    },
     "npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
@@ -4138,6 +4199,17 @@
       "dev": true,
       "requires": {
         "path-key": "^2.0.0"
+      }
+    },
+    "npm-which": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/npm-which/-/npm-which-3.0.1.tgz",
+      "integrity": "sha1-kiXybsOihcIJyuZ8OxGmtKtxQKo=",
+      "dev": true,
+      "requires": {
+        "commander": "^2.9.0",
+        "npm-path": "^2.0.2",
+        "which": "^1.2.10"
       }
     },
     "number-is-nan": {
@@ -4520,6 +4592,12 @@
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
       "dev": true
     },
+    "protochain": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/protochain/-/protochain-1.0.5.tgz",
+      "integrity": "sha1-mRxAfpneJkqt+PgVBLXn+ve/omA=",
+      "dev": true
+    },
     "prr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
@@ -4792,9 +4870,10 @@
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
     },
     "rimraf": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.0.tgz",
-      "integrity": "sha512-4Liqw7ccABzsWV5BzeZeGRSq7KWIgQYzOcmRDEwSX4WAawlQpcAFXZ1Kid72XYrjSnK5yxOS6Gez/iGusYE/Pw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
       "requires": {
         "glob": "^7.1.3"
       }
@@ -4884,6 +4963,15 @@
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.7.0.tgz",
       "integrity": "sha512-ke8UG8ulpFOxO8f8gRYabHQe/ZntKlcig2Mp+8+URDP1D8vJZ0KUt7LYo07q25Z/+JVSgpr/cui9PIp5H6/+nA==",
       "dev": true
+    },
+    "serializerr": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/serializerr/-/serializerr-1.0.3.tgz",
+      "integrity": "sha1-EtTFqhw/+49tHcXzlaqUVVacP5E=",
+      "dev": true,
+      "requires": {
+        "protochain": "^1.0.5"
+      }
     },
     "set-blocking": {
       "version": "2.0.0",
@@ -5415,6 +5503,17 @@
             "ssri": "^6.0.1",
             "unique-filename": "^1.1.1",
             "y18n": "^4.0.0"
+          },
+          "dependencies": {
+            "rimraf": {
+              "version": "2.7.1",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+              "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+              "dev": true,
+              "requires": {
+                "glob": "^7.1.3"
+              }
+            }
           }
         },
         "source-map": {
@@ -6431,6 +6530,14 @@
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "requires": {
+            "glob": "^7.1.3"
+          }
         }
       }
     },
@@ -6670,6 +6777,15 @@
           "requires": {
             "onetime": "^2.0.0",
             "signal-exit": "^3.0.2"
+          }
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
           }
         },
         "rxjs": {

--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "description": "Yeoman generator for Microsoft Teams Apps",
   "main": "generators/app/index.js",
   "scripts": {
-    "build": "node_modules/.bin/webpack",
-    "test": "npm run build && mocha -r ts-node/register tests/**/*.spec.ts --timeout 15000"
+    "build": "rimraf temp-templates/* && node_modules/.bin/webpack",
+    "test": "npm run build && mocha -r ts-node/register tests/**/*.spec.ts --grep 'unit tests -' --timeout 15000",
+    "test-integration": "npm run build && mocha -r ts-node/register tests/**/*.spec.ts --grep 'integration tests -' --timeout 600s"
   },
   "files": [
     "generators"
@@ -57,6 +58,7 @@
     "@types/fs-extra": "^5.0.5",
     "@types/lodash": "^4.14.123",
     "@types/mocha": "^5.2.6",
+    "@types/npm-run": "^5.0.0",
     "@types/semver": "^6.0.1",
     "@types/uuid": "^3.4.5",
     "@types/uuid-validate": "0.0.1",
@@ -70,6 +72,8 @@
     "del": "^4.1.0",
     "fs-extra": "^7.0.1",
     "mocha": "^6.1.4",
+    "npm-run": "^5.0.1",
+    "rimraf": "^3.0.2",
     "ts-loader": "^6.0.0",
     "ts-node": "^8.1.0",
     "webpack": "^4.29.6",

--- a/tests/BotGenerator.spec.ts
+++ b/tests/BotGenerator.spec.ts
@@ -7,7 +7,7 @@ import { describe, it } from 'mocha';
 
 import * as testHelper from './helpers/TestHelper';
 
-describe('teams:bot', async () => {
+describe('unit tests - teams:bot', async () => {
 
     const BOT_HTML_FILES = [
         'src/app/web/bottest01Bot/aboutBottest01Bot.html'

--- a/tests/ConnectorGenerator.spec.ts
+++ b/tests/ConnectorGenerator.spec.ts
@@ -7,7 +7,7 @@ import { describe, it} from 'mocha';
 
 import * as testHelper from './helpers/TestHelper';
 
-describe('teams:connector', function () {
+describe('unit tests - teams:connector', function () {
 
     const CONNECTOR_HTML_FILES = [
         'src/app/web/connectortest01Connector/config.html'

--- a/tests/LocalizationGenerator.spec.ts
+++ b/tests/LocalizationGenerator.spec.ts
@@ -9,7 +9,7 @@ import { describe, it } from 'mocha';
 
 import * as testHelper from './helpers/TestHelper';
 
-describe('teams:localization', function () {
+describe('unit tests - teams:localization', function () {
 
 
     beforeEach(async () => {

--- a/tests/MessageExtensionGenerator.spec.ts
+++ b/tests/MessageExtensionGenerator.spec.ts
@@ -5,7 +5,7 @@ import { describe, it } from 'mocha';
 
 import * as testHelper from './helpers/TestHelper';
 
-describe('teams:messageExtension', function () {
+describe('unit tests - teams:messageExtension', function () {
 
     const MESSAGEEXTSION_HTML_FILES = [
         'src/app/web/messageExtensionTest01MessageExtension/config.html'

--- a/tests/helpers/TestHelper.ts
+++ b/tests/helpers/TestHelper.ts
@@ -1,4 +1,5 @@
 import * as path from 'path';
+import * as npmRun  from 'npm-run';
 
 export const DEPENDENCIES = [
     '../../../generators/tab',
@@ -56,6 +57,19 @@ export const APP_FILES = [
     'src/app/server.ts',
     'src/app/TeamsAppsComponents.ts'
 ];
+
+export async function runNpmCommand(command: string, path: string): Promise<boolean> {
+    return new Promise<boolean>((resolve, reject) => {
+        npmRun.exec(command,{cwd: path}, 
+            function (err: any, stdout: any, stderr: any) {
+                if(err) {
+                    resolve(true);
+                } else {
+                    resolve(false);
+                }
+            });
+    });
+}
 
 export const SCRIPT_FILES = 'src/app/scripts/client.ts';
 

--- a/tests/tabGenerator.spec.ts
+++ b/tests/tabGenerator.spec.ts
@@ -1,662 +1,771 @@
-import * as path from 'path';
-import * as del from 'del';
-import * as fs from 'fs-extra';
-import * as helpers from 'yeoman-test';
-import * as assert from 'yeoman-assert';
-import { describe, it } from 'mocha';
+import * as path from "path";
+import * as del from "del";
+import * as fs from "fs-extra";
+import * as helpers from "yeoman-test";
+import * as assert from "yeoman-assert";
+import { describe, it } from "mocha";
 
-import * as testHelper from './helpers/TestHelper';
+import * as testHelper from "./helpers/TestHelper";
 
-describe('teams:tab', function () {
+const TAB_HTML_FILES = [
+    "src/app/web/tabtest01Tab/index.html",
+    "src/app/web/tabtest01Tab/config.html",
+    "src/app/web/tabtest01Tab/remove.html"
+];
 
-    const TAB_HTML_FILES = [
-        'src/app/web/tabtest01Tab/index.html',
-        'src/app/web/tabtest01Tab/config.html',
-        'src/app/web/tabtest01Tab/remove.html'
-    ];
+const TAB_SCRIPT_FILES = [
+    "src/app/scripts/tabtest01Tab/Tabtest01Tab.tsx",
+    "src/app/scripts/tabtest01Tab/Tabtest01TabConfig.tsx",
+    "src/app/scripts/tabtest01Tab/Tabtest01TabRemove.tsx"
+];
 
-    const TAB_SCRIPT_FILES = [
-        'src/app/scripts/tabtest01Tab/Tabtest01Tab.tsx',
-        'src/app/scripts/tabtest01Tab/Tabtest01TabConfig.tsx',
-        'src/app/scripts/tabtest01Tab/Tabtest01TabRemove.tsx'
-    ];
+const TAB_SCRIPT_TEST_FILES = [
+    "src/app/scripts/tabtest01Tab/__tests__/Tabtest01Tab.spec.tsx",
+    "src/app/scripts/tabtest01Tab/__tests__/Tabtest01TabConfig.spec.tsx",
+    "src/app/scripts/tabtest01Tab/__tests__/Tabtest01TabRemove.spec.tsx"
+];
 
-    const TAB_SCRIPT_TEST_FILES = [
-        'src/app/scripts/tabtest01Tab/__tests__/Tabtest01Tab.spec.tsx',
-        'src/app/scripts/tabtest01Tab/__tests__/Tabtest01TabConfig.spec.tsx',
-        'src/app/scripts/tabtest01Tab/__tests__/Tabtest01TabRemove.spec.tsx'
-    ];
+const TAB_HTML_FILES_STATIC = ["src/app/web/tabtest01Tab/index.html"];
 
-    const TAB_HTML_FILES_STATIC = [
-        'src/app/web/tabtest01Tab/index.html'
-    ];
+const TAB_SCRIPT_FILES_STATIC = [
+    "src/app/scripts/tabtest01Tab/Tabtest01Tab.tsx"
+];
 
-    const TAB_SCRIPT_FILES_STATIC = [
-        'src/app/scripts/tabtest01Tab/Tabtest01Tab.tsx'
-    ];
+const TAB_SCRIPT_TEST_FILES_STATIC = [
+    "src/app/scripts/tabtest01Tab/__tests__/Tabtest01Tab.spec.tsx"
+];
 
-    const TAB_SCRIPT_TEST_FILES_STATIC = [
-        'src/app/scripts/tabtest01Tab/__tests__/Tabtest01Tab.spec.tsx'
-    ];
+const TAB_FILES = "src/app/tabtest01Tab/tabtest01Tab.ts";
 
-    const TAB_FILES = 'src/app/tabtest01Tab/tabtest01Tab.ts';
-
+describe("integration tests - teams:tab", function() {
+  
     beforeEach(async () => {
-        await del([testHelper.TEMP_GENERATOR_PATTERN]);
+      await del([testHelper.TEMP_GENERATOR_PATTERN]);
+    });
+  
+    it("should generate tab project with v1.3 with unit tests", async () => {
+      await helpers
+        .run(testHelper.GENERATOR_PATH)
+        .inDir(testHelper.TEMP_TAB_GENERATOR_PATH + "/tab01")
+        .withArguments(["--no-telemetry"])
+        .withPrompts({
+          solutionName: "tab-test-01",
+          whichFolder: "current",
+          name: "tabtest01",
+          developer: "generator teams developer",
+          manifestVersion: "v1.3",
+          parts: "tab",
+          unitTestsEnabled: true,
+          tabType: "configurable"
+        })
+        .withGenerators(testHelper.DEPENDENCIES);
+  
+      assert.file(testHelper.ROOT_FILES);
+      assert.file(testHelper.TEST_FILES);
+      assert.file(testHelper.APP_FILES);
+      assert.file(testHelper.SCRIPT_FILES);
+      assert.file(testHelper.WEB_FILES);
+      assert.file(testHelper.MANIFEST_FILES);
+  
+      assert.fileContent("src/manifest/manifest.json", testHelper.SCHEMA_13);
+  
+      assert.jsonFileContent("src/manifest/manifest.json", {
+        configurableTabs: [
+          {
+            canUpdateConfiguration: true
+          }
+        ]
+      });
+  
+      assert.file(TAB_HTML_FILES);
+      assert.file(TAB_FILES);
+      assert.file(TAB_SCRIPT_FILES);
+      assert.file(TAB_SCRIPT_TEST_FILES);
+
+      const projectPath = testHelper.TEMP_TAB_GENERATOR_PATH + "/tab01";
+
+      const npmInstallResult = await testHelper.runNpmCommand('npm install', projectPath);
+      assert.equal(false, npmInstallResult)
+
+      const npmRunBuildResult = await testHelper.runNpmCommand('npm run build', projectPath);
+      assert.equal(false, npmRunBuildResult)
     });
 
-    it('should generate tab project with v1.3 with unit tests', async () => {
-        await helpers.run(testHelper.GENERATOR_PATH)
-            .inDir(testHelper.TEMP_TAB_GENERATOR_PATH + '/tab01')
-            .withArguments(['--no-telemetry'])
-            .withPrompts({
-                solutionName: 'tab-test-01',
-                whichFolder: 'current',
-                name: 'tabtest01',
-                developer: 'generator teams developer',
-                manifestVersion: 'v1.3',
-                parts: 'tab',
-                unitTestsEnabled: true,
-                tabType: "configurable"
-            })
-            .withGenerators(testHelper.DEPENDENCIES);
+});
 
-        assert.file(testHelper.ROOT_FILES);
-        assert.file(testHelper.TEST_FILES);
-        assert.file(testHelper.APP_FILES);
-        assert.file(testHelper.SCRIPT_FILES);
-        assert.file(testHelper.WEB_FILES);
-        assert.file(testHelper.MANIFEST_FILES);
+describe("unit tests - teams:tab", function() {
+  
+  beforeEach(async () => {
+    await del([testHelper.TEMP_GENERATOR_PATTERN]);
+  });
 
-        assert.fileContent('src/manifest/manifest.json', testHelper.SCHEMA_13);
+  it("should generate tab project with v1.3 with unit tests", async () => {
+    await helpers
+      .run(testHelper.GENERATOR_PATH)
+      .inDir(testHelper.TEMP_TAB_GENERATOR_PATH + "/tab01")
+      .withArguments(["--no-telemetry"])
+      .withPrompts({
+        solutionName: "tab-test-01",
+        whichFolder: "current",
+        name: "tabtest01",
+        developer: "generator teams developer",
+        manifestVersion: "v1.3",
+        parts: "tab",
+        unitTestsEnabled: true,
+        tabType: "configurable"
+      })
+      .withGenerators(testHelper.DEPENDENCIES);
 
-        assert.jsonFileContent('src/manifest/manifest.json', {
-            configurableTabs: [{
-                "canUpdateConfiguration": true
-            }]
-        });
+    assert.file(testHelper.ROOT_FILES);
+    assert.file(testHelper.TEST_FILES);
+    assert.file(testHelper.APP_FILES);
+    assert.file(testHelper.SCRIPT_FILES);
+    assert.file(testHelper.WEB_FILES);
+    assert.file(testHelper.MANIFEST_FILES);
 
-        assert.file(TAB_HTML_FILES);
-        assert.file(TAB_FILES);
-        assert.file(TAB_SCRIPT_FILES);
-        assert.file(TAB_SCRIPT_TEST_FILES);
+    assert.fileContent("src/manifest/manifest.json", testHelper.SCHEMA_13);
+
+    assert.jsonFileContent("src/manifest/manifest.json", {
+      configurableTabs: [
+        {
+          canUpdateConfiguration: true
+        }
+      ]
     });
 
-    it('should generate a static tab project with v1.3 with unit tests', async () => {
-        await helpers.run(testHelper.GENERATOR_PATH)
-            .inDir(testHelper.TEMP_TAB_GENERATOR_PATH + '/tab01')
-            .withArguments(['--no-telemetry'])
-            .withPrompts({
-                solutionName: 'tab-test-01',
-                whichFolder: 'current',
-                name: 'tabtest01',
-                developer: 'generator teams developer',
-                manifestVersion: 'v1.3',
-                parts: 'tab',
-                unitTestsEnabled: true,
-                tabType: "static"
-            })
-            .withGenerators(testHelper.DEPENDENCIES);
+    assert.file(TAB_HTML_FILES);
+    assert.file(TAB_FILES);
+    assert.file(TAB_SCRIPT_FILES);
+    assert.file(TAB_SCRIPT_TEST_FILES);
+  });
 
-        assert.file(testHelper.ROOT_FILES);
-        assert.file(testHelper.TEST_FILES);
-        assert.file(testHelper.APP_FILES);
-        assert.file(testHelper.SCRIPT_FILES);
-        assert.file(testHelper.WEB_FILES);
-        assert.file(testHelper.MANIFEST_FILES);
+  it("should generate a static tab project with v1.3 with unit tests", async () => {
+    await helpers
+      .run(testHelper.GENERATOR_PATH)
+      .inDir(testHelper.TEMP_TAB_GENERATOR_PATH + "/tab01")
+      .withArguments(["--no-telemetry"])
+      .withPrompts({
+        solutionName: "tab-test-01",
+        whichFolder: "current",
+        name: "tabtest01",
+        developer: "generator teams developer",
+        manifestVersion: "v1.3",
+        parts: "tab",
+        unitTestsEnabled: true,
+        tabType: "static"
+      })
+      .withGenerators(testHelper.DEPENDENCIES);
 
-        assert.fileContent('src/manifest/manifest.json', testHelper.SCHEMA_13);
+    assert.file(testHelper.ROOT_FILES);
+    assert.file(testHelper.TEST_FILES);
+    assert.file(testHelper.APP_FILES);
+    assert.file(testHelper.SCRIPT_FILES);
+    assert.file(testHelper.WEB_FILES);
+    assert.file(testHelper.MANIFEST_FILES);
 
-        assert.jsonFileContent('src/manifest/manifest.json', {
-            staticTabs: [{
-                "scopes": ["personal"]
-            }]
-        });
+    assert.fileContent("src/manifest/manifest.json", testHelper.SCHEMA_13);
 
-        assert.file(TAB_HTML_FILES_STATIC);
-        assert.file(TAB_FILES);
-        assert.file(TAB_SCRIPT_FILES_STATIC);
-        assert.file(TAB_SCRIPT_TEST_FILES_STATIC);
+    assert.jsonFileContent("src/manifest/manifest.json", {
+      staticTabs: [
+        {
+          scopes: ["personal"]
+        }
+      ]
     });
 
-    it('should generate tab project with v1.3 without unit tests', async () => {
-        await helpers.run(testHelper.GENERATOR_PATH)
-            .inDir(testHelper.TEMP_TAB_GENERATOR_PATH + '/tab02')
-            .withArguments(['--no-telemetry'])
-            .withPrompts({
-                solutionName: 'tab-test-01',
-                whichFolder: 'current',
-                name: 'tabtest01',
-                developer: 'generator teams developer',
-                manifestVersion: 'v1.3',
-                parts: 'tab',
-                unitTestsEnabled: false,
-                tabType: "configurable"
-            })
-            .withGenerators(testHelper.DEPENDENCIES);
+    assert.file(TAB_HTML_FILES_STATIC);
+    assert.file(TAB_FILES);
+    assert.file(TAB_SCRIPT_FILES_STATIC);
+    assert.file(TAB_SCRIPT_TEST_FILES_STATIC);
+  });
 
-        assert.file(testHelper.ROOT_FILES);
-        assert.noFile(testHelper.TEST_FILES);
-        assert.file(testHelper.APP_FILES);
-        assert.file(testHelper.SCRIPT_FILES);
-        assert.file(testHelper.WEB_FILES);
-        assert.file(testHelper.MANIFEST_FILES);
+  it("should generate tab project with v1.3 without unit tests", async () => {
+    await helpers
+      .run(testHelper.GENERATOR_PATH)
+      .inDir(testHelper.TEMP_TAB_GENERATOR_PATH + "/tab02")
+      .withArguments(["--no-telemetry"])
+      .withPrompts({
+        solutionName: "tab-test-01",
+        whichFolder: "current",
+        name: "tabtest01",
+        developer: "generator teams developer",
+        manifestVersion: "v1.3",
+        parts: "tab",
+        unitTestsEnabled: false,
+        tabType: "configurable"
+      })
+      .withGenerators(testHelper.DEPENDENCIES);
 
-        assert.fileContent('src/manifest/manifest.json', testHelper.SCHEMA_13);
+    assert.file(testHelper.ROOT_FILES);
+    assert.noFile(testHelper.TEST_FILES);
+    assert.file(testHelper.APP_FILES);
+    assert.file(testHelper.SCRIPT_FILES);
+    assert.file(testHelper.WEB_FILES);
+    assert.file(testHelper.MANIFEST_FILES);
 
-        assert.jsonFileContent('src/manifest/manifest.json', {
-            configurableTabs: [{
-                "canUpdateConfiguration": true
-            }]
-        });
+    assert.fileContent("src/manifest/manifest.json", testHelper.SCHEMA_13);
 
-        assert.file(TAB_HTML_FILES);
-        assert.file(TAB_FILES);
-        assert.file(TAB_SCRIPT_FILES);
-        assert.noFile(TAB_SCRIPT_TEST_FILES);
+    assert.jsonFileContent("src/manifest/manifest.json", {
+      configurableTabs: [
+        {
+          canUpdateConfiguration: true
+        }
+      ]
     });
 
-    it('should generate a static tab project with v1.3 without unit tests', async () => {
-        await helpers.run(testHelper.GENERATOR_PATH)
-            .inDir(testHelper.TEMP_TAB_GENERATOR_PATH + '/tab02')
-            .withArguments(['--no-telemetry'])
-            .withPrompts({
-                solutionName: 'tab-test-01',
-                whichFolder: 'current',
-                name: 'tabtest01',
-                developer: 'generator teams developer',
-                manifestVersion: 'v1.3',
-                parts: 'tab',
-                unitTestsEnabled: false,
-                tabType: "static"
-            })
-            .withGenerators(testHelper.DEPENDENCIES);
+    assert.file(TAB_HTML_FILES);
+    assert.file(TAB_FILES);
+    assert.file(TAB_SCRIPT_FILES);
+    assert.noFile(TAB_SCRIPT_TEST_FILES);
+  });
 
-        assert.file(testHelper.ROOT_FILES);
-        assert.noFile(testHelper.TEST_FILES);
-        assert.file(testHelper.APP_FILES);
-        assert.file(testHelper.SCRIPT_FILES);
-        assert.file(testHelper.WEB_FILES);
-        assert.file(testHelper.MANIFEST_FILES);
+  it("should generate a static tab project with v1.3 without unit tests", async () => {
+    await helpers
+      .run(testHelper.GENERATOR_PATH)
+      .inDir(testHelper.TEMP_TAB_GENERATOR_PATH + "/tab02")
+      .withArguments(["--no-telemetry"])
+      .withPrompts({
+        solutionName: "tab-test-01",
+        whichFolder: "current",
+        name: "tabtest01",
+        developer: "generator teams developer",
+        manifestVersion: "v1.3",
+        parts: "tab",
+        unitTestsEnabled: false,
+        tabType: "static"
+      })
+      .withGenerators(testHelper.DEPENDENCIES);
 
-        assert.fileContent('src/manifest/manifest.json', testHelper.SCHEMA_13);
+    assert.file(testHelper.ROOT_FILES);
+    assert.noFile(testHelper.TEST_FILES);
+    assert.file(testHelper.APP_FILES);
+    assert.file(testHelper.SCRIPT_FILES);
+    assert.file(testHelper.WEB_FILES);
+    assert.file(testHelper.MANIFEST_FILES);
 
-        assert.jsonFileContent('src/manifest/manifest.json', {
-            staticTabs: [{
-                "scopes": ["personal"]
-            }]
-        });
+    assert.fileContent("src/manifest/manifest.json", testHelper.SCHEMA_13);
 
-        assert.file(TAB_HTML_FILES_STATIC);
-        assert.file(TAB_FILES);
-        assert.file(TAB_SCRIPT_FILES_STATIC);
-        assert.noFile(TAB_SCRIPT_TEST_FILES_STATIC);
+    assert.jsonFileContent("src/manifest/manifest.json", {
+      staticTabs: [
+        {
+          scopes: ["personal"]
+        }
+      ]
     });
 
-    it('should generate tab project with v1.4 with unit tests', async () => {
-        await helpers.run(testHelper.GENERATOR_PATH)
-            .inDir(testHelper.TEMP_TAB_GENERATOR_PATH + '/tab01-14')
-            .withArguments(['--no-telemetry'])
-            .withPrompts({
-                solutionName: 'tab-test-01',
-                whichFolder: 'current',
-                name: 'tabtest01',
-                developer: 'generator teams developer',
-                manifestVersion: 'v1.4',
-                parts: 'tab',
-                unitTestsEnabled: true,
-                tabType: "configurable"
-            })
-            .withGenerators(testHelper.DEPENDENCIES);
+    assert.file(TAB_HTML_FILES_STATIC);
+    assert.file(TAB_FILES);
+    assert.file(TAB_SCRIPT_FILES_STATIC);
+    assert.noFile(TAB_SCRIPT_TEST_FILES_STATIC);
+  });
 
-        assert.file(testHelper.ROOT_FILES);
-        assert.file(testHelper.TEST_FILES);
-        assert.file(testHelper.APP_FILES);
-        assert.file(testHelper.SCRIPT_FILES);
-        assert.file(testHelper.WEB_FILES);
-        assert.file(testHelper.MANIFEST_FILES);
+  it("should generate tab project with v1.4 with unit tests", async () => {
+    await helpers
+      .run(testHelper.GENERATOR_PATH)
+      .inDir(testHelper.TEMP_TAB_GENERATOR_PATH + "/tab01-14")
+      .withArguments(["--no-telemetry"])
+      .withPrompts({
+        solutionName: "tab-test-01",
+        whichFolder: "current",
+        name: "tabtest01",
+        developer: "generator teams developer",
+        manifestVersion: "v1.4",
+        parts: "tab",
+        unitTestsEnabled: true,
+        tabType: "configurable"
+      })
+      .withGenerators(testHelper.DEPENDENCIES);
 
-        assert.fileContent('src/manifest/manifest.json', testHelper.SCHEMA_14);
+    assert.file(testHelper.ROOT_FILES);
+    assert.file(testHelper.TEST_FILES);
+    assert.file(testHelper.APP_FILES);
+    assert.file(testHelper.SCRIPT_FILES);
+    assert.file(testHelper.WEB_FILES);
+    assert.file(testHelper.MANIFEST_FILES);
 
-        assert.jsonFileContent('src/manifest/manifest.json', {
-            configurableTabs: [{
-                "canUpdateConfiguration": true
-            }]
-        });
+    assert.fileContent("src/manifest/manifest.json", testHelper.SCHEMA_14);
 
-        assert.file(TAB_HTML_FILES);
-        assert.file(TAB_FILES);
-        assert.file(TAB_SCRIPT_FILES);
-        assert.file(TAB_SCRIPT_TEST_FILES);
+    assert.jsonFileContent("src/manifest/manifest.json", {
+      configurableTabs: [
+        {
+          canUpdateConfiguration: true
+        }
+      ]
     });
 
-    it('should generate tab project with v1.4 without unit tests', async () => {
-        await helpers.run(testHelper.GENERATOR_PATH)
-            .inDir(testHelper.TEMP_TAB_GENERATOR_PATH + '/tab02-14')
-            .withArguments(['--no-telemetry'])
-            .withPrompts({
-                solutionName: 'tab-test-01',
-                whichFolder: 'current',
-                name: 'tabtest01',
-                developer: 'generator teams developer',
-                manifestVersion: 'v1.4',
-                parts: 'tab',
-                unitTestsEnabled: false,
-                tabType: "configurable"
-            })
-            .withGenerators(testHelper.DEPENDENCIES);
+    assert.file(TAB_HTML_FILES);
+    assert.file(TAB_FILES);
+    assert.file(TAB_SCRIPT_FILES);
+    assert.file(TAB_SCRIPT_TEST_FILES);
+  });
 
-        assert.file(testHelper.ROOT_FILES);
-        assert.noFile(testHelper.TEST_FILES);
-        assert.file(testHelper.APP_FILES);
-        assert.file(testHelper.SCRIPT_FILES);
-        assert.file(testHelper.WEB_FILES);
-        assert.file(testHelper.MANIFEST_FILES);
+  it("should generate tab project with v1.4 without unit tests", async () => {
+    await helpers
+      .run(testHelper.GENERATOR_PATH)
+      .inDir(testHelper.TEMP_TAB_GENERATOR_PATH + "/tab02-14")
+      .withArguments(["--no-telemetry"])
+      .withPrompts({
+        solutionName: "tab-test-01",
+        whichFolder: "current",
+        name: "tabtest01",
+        developer: "generator teams developer",
+        manifestVersion: "v1.4",
+        parts: "tab",
+        unitTestsEnabled: false,
+        tabType: "configurable"
+      })
+      .withGenerators(testHelper.DEPENDENCIES);
 
-        assert.fileContent('src/manifest/manifest.json', testHelper.SCHEMA_14);
+    assert.file(testHelper.ROOT_FILES);
+    assert.noFile(testHelper.TEST_FILES);
+    assert.file(testHelper.APP_FILES);
+    assert.file(testHelper.SCRIPT_FILES);
+    assert.file(testHelper.WEB_FILES);
+    assert.file(testHelper.MANIFEST_FILES);
 
-        assert.jsonFileContent('src/manifest/manifest.json', {
-            configurableTabs: [{
-                "canUpdateConfiguration": true
-            }]
-        });
+    assert.fileContent("src/manifest/manifest.json", testHelper.SCHEMA_14);
 
-        assert.file(TAB_HTML_FILES);
-        assert.file(TAB_FILES);
-        assert.file(TAB_SCRIPT_FILES);
-        assert.noFile(TAB_SCRIPT_TEST_FILES);
+    assert.jsonFileContent("src/manifest/manifest.json", {
+      configurableTabs: [
+        {
+          canUpdateConfiguration: true
+        }
+      ]
     });
 
-    it('should generate a static tab project with v1.4 without unit tests', async () => {
-        await helpers.run(testHelper.GENERATOR_PATH)
-            .inDir(testHelper.TEMP_TAB_GENERATOR_PATH + '/tab02-14')
-            .withArguments(['--no-telemetry'])
-            .withPrompts({
-                solutionName: 'tab-test-01',
-                whichFolder: 'current',
-                name: 'tabtest01',
-                developer: 'generator teams developer',
-                manifestVersion: 'v1.4',
-                parts: 'tab',
-                unitTestsEnabled: false,
-                tabType: "static"
-            })
-            .withGenerators(testHelper.DEPENDENCIES);
+    assert.file(TAB_HTML_FILES);
+    assert.file(TAB_FILES);
+    assert.file(TAB_SCRIPT_FILES);
+    assert.noFile(TAB_SCRIPT_TEST_FILES);
+  });
 
-        assert.file(testHelper.ROOT_FILES);
-        assert.noFile(testHelper.TEST_FILES);
-        assert.file(testHelper.APP_FILES);
-        assert.file(testHelper.SCRIPT_FILES);
-        assert.file(testHelper.WEB_FILES);
-        assert.file(testHelper.MANIFEST_FILES);
+  it("should generate a static tab project with v1.4 without unit tests", async () => {
+    await helpers
+      .run(testHelper.GENERATOR_PATH)
+      .inDir(testHelper.TEMP_TAB_GENERATOR_PATH + "/tab02-14")
+      .withArguments(["--no-telemetry"])
+      .withPrompts({
+        solutionName: "tab-test-01",
+        whichFolder: "current",
+        name: "tabtest01",
+        developer: "generator teams developer",
+        manifestVersion: "v1.4",
+        parts: "tab",
+        unitTestsEnabled: false,
+        tabType: "static"
+      })
+      .withGenerators(testHelper.DEPENDENCIES);
 
-        assert.fileContent('src/manifest/manifest.json', testHelper.SCHEMA_14);
+    assert.file(testHelper.ROOT_FILES);
+    assert.noFile(testHelper.TEST_FILES);
+    assert.file(testHelper.APP_FILES);
+    assert.file(testHelper.SCRIPT_FILES);
+    assert.file(testHelper.WEB_FILES);
+    assert.file(testHelper.MANIFEST_FILES);
 
-        assert.jsonFileContent('src/manifest/manifest.json', {
-            staticTabs: [{
-                "scopes": ["personal"]
-            }]
-        });
+    assert.fileContent("src/manifest/manifest.json", testHelper.SCHEMA_14);
 
-        assert.file(TAB_HTML_FILES_STATIC);
-        assert.file(TAB_FILES);
-        assert.file(TAB_SCRIPT_FILES_STATIC);
-        assert.noFile(TAB_SCRIPT_TEST_FILES_STATIC);
+    assert.jsonFileContent("src/manifest/manifest.json", {
+      staticTabs: [
+        {
+          scopes: ["personal"]
+        }
+      ]
     });
 
-    it('should generate tab project with v1.4 with SharePoint config', async () => {
-        await helpers.run(testHelper.GENERATOR_PATH)
-            .inDir(testHelper.TEMP_TAB_GENERATOR_PATH + '/tab02-14')
-            .withArguments(['--no-telemetry'])
-            .withPrompts({
-                solutionName: 'tab-test-01',
-                whichFolder: 'current',
-                name: 'tabtest01',
-                developer: 'generator teams developer',
-                manifestVersion: 'v1.4',
-                parts: 'tab',
-                unitTestsEnabled: false,
-                tabSharePoint: true,
-                tabSharePointHosts: ["sharePointFullPage", "sharePointWebPart"],
-                tabType: "configurable"
-            })
-            .withGenerators(testHelper.DEPENDENCIES);
+    assert.file(TAB_HTML_FILES_STATIC);
+    assert.file(TAB_FILES);
+    assert.file(TAB_SCRIPT_FILES_STATIC);
+    assert.noFile(TAB_SCRIPT_TEST_FILES_STATIC);
+  });
 
-        assert.file(testHelper.ROOT_FILES);
-        assert.noFile(testHelper.TEST_FILES);
-        assert.file(testHelper.APP_FILES);
-        assert.file(testHelper.SCRIPT_FILES);
-        assert.file(testHelper.WEB_FILES);
-        assert.file(testHelper.MANIFEST_FILES);
+  it("should generate tab project with v1.4 with SharePoint config", async () => {
+    await helpers
+      .run(testHelper.GENERATOR_PATH)
+      .inDir(testHelper.TEMP_TAB_GENERATOR_PATH + "/tab02-14")
+      .withArguments(["--no-telemetry"])
+      .withPrompts({
+        solutionName: "tab-test-01",
+        whichFolder: "current",
+        name: "tabtest01",
+        developer: "generator teams developer",
+        manifestVersion: "v1.4",
+        parts: "tab",
+        unitTestsEnabled: false,
+        tabSharePoint: true,
+        tabSharePointHosts: ["sharePointFullPage", "sharePointWebPart"],
+        tabType: "configurable"
+      })
+      .withGenerators(testHelper.DEPENDENCIES);
 
-        assert.fileContent('src/manifest/manifest.json', testHelper.SCHEMA_14);
-        assert.jsonFileContent('src/manifest/manifest.json', {
-            configurableTabs: [{
-                sharePointPreviewImage: "https://{{HOSTNAME}}/assets/tabtest01Tab-preview.png",
-                supportedSharePointHosts: [
-                    "sharePointFullPage",
-                    "sharePointWebPart"
-                ]
-            }]
-        });
+    assert.file(testHelper.ROOT_FILES);
+    assert.noFile(testHelper.TEST_FILES);
+    assert.file(testHelper.APP_FILES);
+    assert.file(testHelper.SCRIPT_FILES);
+    assert.file(testHelper.WEB_FILES);
+    assert.file(testHelper.MANIFEST_FILES);
 
-        assert.file(TAB_HTML_FILES);
-        assert.file(TAB_FILES);
-        assert.file(TAB_SCRIPT_FILES);
-        assert.noFile(TAB_SCRIPT_TEST_FILES);
+    assert.fileContent("src/manifest/manifest.json", testHelper.SCHEMA_14);
+    assert.jsonFileContent("src/manifest/manifest.json", {
+      configurableTabs: [
+        {
+          sharePointPreviewImage:
+            "https://{{HOSTNAME}}/assets/tabtest01Tab-preview.png",
+          supportedSharePointHosts: ["sharePointFullPage", "sharePointWebPart"]
+        }
+      ]
     });
 
-    it('should generate tab project with v1.5 without unit tests', async () => {
-        await helpers.run(testHelper.GENERATOR_PATH)
-            .inDir(testHelper.TEMP_TAB_GENERATOR_PATH + '/tab02-15')
-            .withArguments(['--no-telemetry'])
-            .withPrompts({
-                solutionName: 'tab-test-01',
-                whichFolder: 'current',
-                name: 'tabtest01',
-                developer: 'generator teams developer',
-                manifestVersion: 'v1.5',
-                parts: 'tab',
-                unitTestsEnabled: false,
-                tabType: "configurable"
-            })
-            .withGenerators(testHelper.DEPENDENCIES);
+    assert.file(TAB_HTML_FILES);
+    assert.file(TAB_FILES);
+    assert.file(TAB_SCRIPT_FILES);
+    assert.noFile(TAB_SCRIPT_TEST_FILES);
+  });
 
-        assert.file(testHelper.ROOT_FILES);
-        assert.noFile(testHelper.TEST_FILES);
-        assert.file(testHelper.APP_FILES);
-        assert.file(testHelper.SCRIPT_FILES);
-        assert.file(testHelper.WEB_FILES);
-        assert.file(testHelper.MANIFEST_FILES);
+  it("should generate tab project with v1.5 without unit tests", async () => {
+    await helpers
+      .run(testHelper.GENERATOR_PATH)
+      .inDir(testHelper.TEMP_TAB_GENERATOR_PATH + "/tab02-15")
+      .withArguments(["--no-telemetry"])
+      .withPrompts({
+        solutionName: "tab-test-01",
+        whichFolder: "current",
+        name: "tabtest01",
+        developer: "generator teams developer",
+        manifestVersion: "v1.5",
+        parts: "tab",
+        unitTestsEnabled: false,
+        tabType: "configurable"
+      })
+      .withGenerators(testHelper.DEPENDENCIES);
 
-        assert.fileContent('src/manifest/manifest.json', testHelper.SCHEMA_15);
+    assert.file(testHelper.ROOT_FILES);
+    assert.noFile(testHelper.TEST_FILES);
+    assert.file(testHelper.APP_FILES);
+    assert.file(testHelper.SCRIPT_FILES);
+    assert.file(testHelper.WEB_FILES);
+    assert.file(testHelper.MANIFEST_FILES);
 
-        assert.jsonFileContent('src/manifest/manifest.json', {
-            configurableTabs: [{
-                "canUpdateConfiguration": true
-            }]
-        });
+    assert.fileContent("src/manifest/manifest.json", testHelper.SCHEMA_15);
 
-        assert.file(TAB_HTML_FILES);
-        assert.file(TAB_FILES);
-        assert.file(TAB_SCRIPT_FILES);
-        assert.noFile(TAB_SCRIPT_TEST_FILES);
+    assert.jsonFileContent("src/manifest/manifest.json", {
+      configurableTabs: [
+        {
+          canUpdateConfiguration: true
+        }
+      ]
     });
 
-    it('should generate tab project with v1.5 with SharePoint config', async () => {
-        await helpers.run(testHelper.GENERATOR_PATH)
-            .inDir(testHelper.TEMP_TAB_GENERATOR_PATH + '/tab02-15')
-            .withArguments(['--no-telemetry'])
-            .withPrompts({
-                solutionName: 'tab-test-01',
-                whichFolder: 'current',
-                name: 'tabtest01',
-                developer: 'generator teams developer',
-                manifestVersion: 'v1.5',
-                parts: 'tab',
-                unitTestsEnabled: false,
-                tabSharePoint: true,
-                tabSharePointHosts: ["sharePointFullPage", "sharePointWebPart"],
-                tabType: "configurable"
-            })
-            .withGenerators(testHelper.DEPENDENCIES);
+    assert.file(TAB_HTML_FILES);
+    assert.file(TAB_FILES);
+    assert.file(TAB_SCRIPT_FILES);
+    assert.noFile(TAB_SCRIPT_TEST_FILES);
+  });
 
-        assert.file(testHelper.ROOT_FILES);
-        assert.noFile(testHelper.TEST_FILES);
-        assert.file(testHelper.APP_FILES);
-        assert.file(testHelper.SCRIPT_FILES);
-        assert.file(testHelper.WEB_FILES);
-        assert.file(testHelper.MANIFEST_FILES);
+  it("should generate tab project with v1.5 with SharePoint config", async () => {
+    await helpers
+      .run(testHelper.GENERATOR_PATH)
+      .inDir(testHelper.TEMP_TAB_GENERATOR_PATH + "/tab02-15")
+      .withArguments(["--no-telemetry"])
+      .withPrompts({
+        solutionName: "tab-test-01",
+        whichFolder: "current",
+        name: "tabtest01",
+        developer: "generator teams developer",
+        manifestVersion: "v1.5",
+        parts: "tab",
+        unitTestsEnabled: false,
+        tabSharePoint: true,
+        tabSharePointHosts: ["sharePointFullPage", "sharePointWebPart"],
+        tabType: "configurable"
+      })
+      .withGenerators(testHelper.DEPENDENCIES);
 
-        assert.fileContent('src/manifest/manifest.json', testHelper.SCHEMA_15);
-        assert.jsonFileContent('src/manifest/manifest.json', {
-            configurableTabs: [{
-                sharePointPreviewImage: "https://{{HOSTNAME}}/assets/tabtest01Tab-preview.png",
-                supportedSharePointHosts: [
-                    "sharePointFullPage",
-                    "sharePointWebPart"
-                ]
-            }]
-        });
+    assert.file(testHelper.ROOT_FILES);
+    assert.noFile(testHelper.TEST_FILES);
+    assert.file(testHelper.APP_FILES);
+    assert.file(testHelper.SCRIPT_FILES);
+    assert.file(testHelper.WEB_FILES);
+    assert.file(testHelper.MANIFEST_FILES);
 
-        assert.file(TAB_HTML_FILES);
-        assert.file(TAB_FILES);
-        assert.file(TAB_SCRIPT_FILES);
-        assert.noFile(TAB_SCRIPT_TEST_FILES);
+    assert.fileContent("src/manifest/manifest.json", testHelper.SCHEMA_15);
+    assert.jsonFileContent("src/manifest/manifest.json", {
+      configurableTabs: [
+        {
+          sharePointPreviewImage:
+            "https://{{HOSTNAME}}/assets/tabtest01Tab-preview.png",
+          supportedSharePointHosts: ["sharePointFullPage", "sharePointWebPart"]
+        }
+      ]
     });
 
-    it('should generate tab project with v1.5 with MPM Id', async () => {
-        await helpers.run(testHelper.GENERATOR_PATH)
-            .inDir(testHelper.TEMP_TAB_GENERATOR_PATH + '/tab02-15-mpn')
-            .withArguments(['--no-telemetry'])
-            .withPrompts({
-                solutionName: 'tab-test-01',
-                whichFolder: 'current',
-                name: 'tabtest01',
-                developer: 'generator teams developer',
-                manifestVersion: 'v1.5',
-                parts: 'tab',
-                unitTestsEnabled: false,
-                mpnId: "1234567890",
-                tabType: "configurable"
-            })
-            .withGenerators(testHelper.DEPENDENCIES);
+    assert.file(TAB_HTML_FILES);
+    assert.file(TAB_FILES);
+    assert.file(TAB_SCRIPT_FILES);
+    assert.noFile(TAB_SCRIPT_TEST_FILES);
+  });
 
-        assert.file(testHelper.ROOT_FILES);
-        assert.noFile(testHelper.TEST_FILES);
-        assert.file(testHelper.APP_FILES);
-        assert.file(testHelper.SCRIPT_FILES);
-        assert.file(testHelper.WEB_FILES);
-        assert.file(testHelper.MANIFEST_FILES);
+  it("should generate tab project with v1.5 with MPM Id", async () => {
+    await helpers
+      .run(testHelper.GENERATOR_PATH)
+      .inDir(testHelper.TEMP_TAB_GENERATOR_PATH + "/tab02-15-mpn")
+      .withArguments(["--no-telemetry"])
+      .withPrompts({
+        solutionName: "tab-test-01",
+        whichFolder: "current",
+        name: "tabtest01",
+        developer: "generator teams developer",
+        manifestVersion: "v1.5",
+        parts: "tab",
+        unitTestsEnabled: false,
+        mpnId: "1234567890",
+        tabType: "configurable"
+      })
+      .withGenerators(testHelper.DEPENDENCIES);
 
-        assert.fileContent('src/manifest/manifest.json', testHelper.SCHEMA_15);
-        assert.jsonFileContent('src/manifest/manifest.json', {
-            developer: {
-                mpnId: "1234567890"
-            }
-        });
-        assert.jsonFileContent('src/manifest/manifest.json', {
-            configurableTabs: [{
-                "canUpdateConfiguration": true
-            }]
-        });
-        assert.file(TAB_HTML_FILES);
-        assert.file(TAB_FILES);
-        assert.file(TAB_SCRIPT_FILES);
-        assert.noFile(TAB_SCRIPT_TEST_FILES);
+    assert.file(testHelper.ROOT_FILES);
+    assert.noFile(testHelper.TEST_FILES);
+    assert.file(testHelper.APP_FILES);
+    assert.file(testHelper.SCRIPT_FILES);
+    assert.file(testHelper.WEB_FILES);
+    assert.file(testHelper.MANIFEST_FILES);
+
+    assert.fileContent("src/manifest/manifest.json", testHelper.SCHEMA_15);
+    assert.jsonFileContent("src/manifest/manifest.json", {
+      developer: {
+        mpnId: "1234567890"
+      }
+    });
+    assert.jsonFileContent("src/manifest/manifest.json", {
+      configurableTabs: [
+        {
+          canUpdateConfiguration: true
+        }
+      ]
+    });
+    assert.file(TAB_HTML_FILES);
+    assert.file(TAB_FILES);
+    assert.file(TAB_SCRIPT_FILES);
+    assert.noFile(TAB_SCRIPT_TEST_FILES);
+  });
+
+  it("should generate tab project with devPreview with unit tests", async () => {
+    await helpers
+      .run(testHelper.GENERATOR_PATH)
+      .inDir(testHelper.TEMP_TAB_GENERATOR_PATH + "/tab03")
+      .withArguments(["--no-telemetry"])
+      .withPrompts({
+        solutionName: "tab-test-01",
+        whichFolder: "current",
+        name: "tabtest01",
+        developer: "generator teams developer",
+        manifestVersion: "devPreview",
+        parts: "tab",
+        unitTestsEnabled: true,
+        tabType: "configurable"
+      })
+      .withGenerators(testHelper.DEPENDENCIES);
+
+    assert.file(testHelper.ROOT_FILES);
+    assert.file(testHelper.TEST_FILES);
+    assert.file(testHelper.APP_FILES);
+    assert.file(testHelper.SCRIPT_FILES);
+    assert.file(testHelper.WEB_FILES);
+    assert.file(testHelper.MANIFEST_FILES);
+
+    assert.fileContent(
+      "src/manifest/manifest.json",
+      testHelper.SCHEMA_DEVPREVIEW
+    );
+
+    assert.jsonFileContent("src/manifest/manifest.json", {
+      configurableTabs: [
+        {
+          canUpdateConfiguration: true
+        }
+      ]
     });
 
+    assert.file(TAB_HTML_FILES);
+    assert.file(TAB_FILES);
+    assert.file(TAB_SCRIPT_FILES);
+    assert.file(TAB_SCRIPT_TEST_FILES);
+  });
 
-    it('should generate tab project with devPreview with unit tests', async () => {
-        await helpers.run(testHelper.GENERATOR_PATH)
-            .inDir(testHelper.TEMP_TAB_GENERATOR_PATH + '/tab03')
-            .withArguments(['--no-telemetry'])
-            .withPrompts({
-                solutionName: 'tab-test-01',
-                whichFolder: 'current',
-                name: 'tabtest01',
-                developer: 'generator teams developer',
-                manifestVersion: 'devPreview',
-                parts: 'tab',
-                unitTestsEnabled: true,
-                tabType: "configurable"
-            })
-            .withGenerators(testHelper.DEPENDENCIES);
+  it("should generate tab project with devPreview without unit tests", async () => {
+    await helpers
+      .run(testHelper.GENERATOR_PATH)
+      .inDir(testHelper.TEMP_TAB_GENERATOR_PATH + "/tab04")
+      .withArguments(["--no-telemetry"])
+      .withPrompts({
+        solutionName: "tab-test-01",
+        whichFolder: "current",
+        name: "tabtest01",
+        developer: "generator teams developer",
+        manifestVersion: "devPreview",
+        parts: "tab",
+        unitTestsEnabled: false,
+        tabType: "configurable"
+      })
+      .withGenerators(testHelper.DEPENDENCIES);
 
-        assert.file(testHelper.ROOT_FILES);
-        assert.file(testHelper.TEST_FILES);
-        assert.file(testHelper.APP_FILES);
-        assert.file(testHelper.SCRIPT_FILES);
-        assert.file(testHelper.WEB_FILES);
-        assert.file(testHelper.MANIFEST_FILES);
+    assert.file(testHelper.ROOT_FILES);
+    assert.noFile(testHelper.TEST_FILES);
+    assert.file(testHelper.APP_FILES);
+    assert.file(testHelper.SCRIPT_FILES);
+    assert.file(testHelper.WEB_FILES);
+    assert.file(testHelper.MANIFEST_FILES);
 
-        assert.fileContent('src/manifest/manifest.json', testHelper.SCHEMA_DEVPREVIEW);
+    assert.fileContent(
+      "src/manifest/manifest.json",
+      testHelper.SCHEMA_DEVPREVIEW
+    );
 
-        assert.jsonFileContent('src/manifest/manifest.json', {
-            configurableTabs: [{
-                "canUpdateConfiguration": true
-            }]
-        });
-
-        assert.file(TAB_HTML_FILES);
-        assert.file(TAB_FILES);
-        assert.file(TAB_SCRIPT_FILES);
-        assert.file(TAB_SCRIPT_TEST_FILES);
+    assert.jsonFileContent("src/manifest/manifest.json", {
+      configurableTabs: [
+        {
+          canUpdateConfiguration: true
+        }
+      ]
     });
 
-    it('should generate tab project with devPreview without unit tests', async () => {
-        await helpers.run(testHelper.GENERATOR_PATH)
-            .inDir(testHelper.TEMP_TAB_GENERATOR_PATH + '/tab04')
-            .withArguments(['--no-telemetry'])
-            .withPrompts({
-                solutionName: 'tab-test-01',
-                whichFolder: 'current',
-                name: 'tabtest01',
-                developer: 'generator teams developer',
-                manifestVersion: 'devPreview',
-                parts: 'tab',
-                unitTestsEnabled: false,
-                tabType: "configurable"
-            })
-            .withGenerators(testHelper.DEPENDENCIES);
+    assert.file(TAB_HTML_FILES);
+    assert.file(TAB_FILES);
+    assert.file(TAB_SCRIPT_FILES);
+    assert.noFile(TAB_SCRIPT_TEST_FILES);
+  });
 
-        assert.file(testHelper.ROOT_FILES);
-        assert.noFile(testHelper.TEST_FILES);
-        assert.file(testHelper.APP_FILES);
-        assert.file(testHelper.SCRIPT_FILES);
-        assert.file(testHelper.WEB_FILES);
-        assert.file(testHelper.MANIFEST_FILES);
+  it("should generate tab project applicatiaon insights", async () => {
+    await helpers
+      .run(testHelper.GENERATOR_PATH)
+      .inDir(testHelper.TEMP_TAB_GENERATOR_PATH + "/tab05")
+      .withArguments(["--no-telemetry"])
+      .withPrompts({
+        solutionName: "tab-test-01",
+        whichFolder: "current",
+        name: "tabtest01",
+        developer: "generator teams developer",
+        manifestVersion: "v1.3",
+        parts: "tab",
+        unitTestsEnabled: false,
+        useAzureAppInsights: true,
+        azureAppInsightsKey: "12341234-1234-1234-1234-123412341234",
+        tabType: "configurable"
+      })
+      .withGenerators(testHelper.DEPENDENCIES);
 
-        assert.fileContent('src/manifest/manifest.json', testHelper.SCHEMA_DEVPREVIEW);
+    assert.fileContent(
+      ".env",
+      "APPINSIGHTS_INSTRUMENTATIONKEY=12341234-1234-1234-1234-123412341234"
+    );
+    assert.fileContent("package.json", `"applicationinsights": "^1.3.1"`);
+    assert.fileContent(
+      "src/app/web/index.html",
+      `var appInsights = window.appInsights`
+    );
+  });
 
-        assert.jsonFileContent('src/manifest/manifest.json', {
-            configurableTabs: [{
-                "canUpdateConfiguration": true
-            }]
-        });
+  it("should generate tab project with no applicatiaon insights", async () => {
+    await helpers
+      .run(testHelper.GENERATOR_PATH)
+      .inDir(testHelper.TEMP_TAB_GENERATOR_PATH + "/tab06")
+      .withArguments(["--no-telemetry"])
+      .withPrompts({
+        solutionName: "tab-test-01",
+        whichFolder: "current",
+        name: "tabtest01",
+        developer: "generator teams developer",
+        manifestVersion: "v1.3",
+        parts: "tab",
+        unitTestsEnabled: false,
+        useAzureAppInsights: false,
+        tabType: "configurable"
+      })
+      .withGenerators(testHelper.DEPENDENCIES);
 
-        assert.file(TAB_HTML_FILES);
-        assert.file(TAB_FILES);
-        assert.file(TAB_SCRIPT_FILES);
-        assert.noFile(TAB_SCRIPT_TEST_FILES);
+    assert.fileContent(".env", "APPINSIGHTS_INSTRUMENTATIONKEY=");
+    assert.noFileContent("package.json", `"applicationinsights": "^1.3.1"`);
+    assert.noFileContent(
+      "src/app/web/index.html",
+      `var appInsights = window.appInsights`
+    );
+  });
+
+  it("should generate tab project scoped to groupchat only", async () => {
+    await helpers
+      .run(testHelper.GENERATOR_PATH)
+      .inDir(testHelper.TEMP_TAB_GENERATOR_PATH + "/tab06")
+      .withArguments(["--no-telemetry"])
+      .withPrompts({
+        solutionName: "tab-test-01",
+        whichFolder: "current",
+        name: "tabtest01",
+        developer: "generator teams developer",
+        manifestVersion: "v1.5",
+        parts: "tab",
+        tabScopes: ["groupchat"],
+        tabType: "configurable"
+      })
+      .withGenerators(testHelper.DEPENDENCIES);
+
+    assert.jsonFileContent("src/manifest/manifest.json", {
+      configurableTabs: [
+        {
+          scopes: ["groupchat"]
+        }
+      ]
     });
+  });
 
-    it('should generate tab project applicatiaon insights', async () => {
-        await helpers.run(testHelper.GENERATOR_PATH)
-            .inDir(testHelper.TEMP_TAB_GENERATOR_PATH + '/tab05')
-            .withArguments(['--no-telemetry'])
-            .withPrompts({
-                solutionName: 'tab-test-01',
-                whichFolder: 'current',
-                name: 'tabtest01',
-                developer: 'generator teams developer',
-                manifestVersion: 'v1.3',
-                parts: 'tab',
-                unitTestsEnabled: false,
-                useAzureAppInsights: true,
-                azureAppInsightsKey: "12341234-1234-1234-1234-123412341234",
-                tabType: "configurable"
-            })
-            .withGenerators(testHelper.DEPENDENCIES);
+  it("should generate tab project scoped to team only", async () => {
+    await helpers
+      .run(testHelper.GENERATOR_PATH)
+      .inDir(testHelper.TEMP_TAB_GENERATOR_PATH + "/tab06")
+      .withArguments(["--no-telemetry"])
+      .withPrompts({
+        solutionName: "tab-test-01",
+        whichFolder: "current",
+        name: "tabtest01",
+        developer: "generator teams developer",
+        manifestVersion: "v1.5",
+        parts: "tab",
+        tabScopes: ["team"],
+        tabType: "configurable"
+      })
+      .withGenerators(testHelper.DEPENDENCIES);
 
-        assert.fileContent(".env", "APPINSIGHTS_INSTRUMENTATIONKEY=12341234-1234-1234-1234-123412341234");
-        assert.fileContent("package.json", `"applicationinsights": "^1.3.1"`);
-        assert.fileContent("src/app/web/index.html", `var appInsights = window.appInsights`);
+    assert.jsonFileContent("src/manifest/manifest.json", {
+      configurableTabs: [
+        {
+          scopes: ["team"]
+        }
+      ]
     });
+  });
 
-    it('should generate tab project with no applicatiaon insights', async () => {
-        await helpers.run(testHelper.GENERATOR_PATH)
-            .inDir(testHelper.TEMP_TAB_GENERATOR_PATH + '/tab06')
-            .withArguments(['--no-telemetry'])
-            .withPrompts({
-                solutionName: 'tab-test-01',
-                whichFolder: 'current',
-                name: 'tabtest01',
-                developer: 'generator teams developer',
-                manifestVersion: 'v1.3',
-                parts: 'tab',
-                unitTestsEnabled: false,
-                useAzureAppInsights: false,
-                tabType: "configurable"
-            })
-            .withGenerators(testHelper.DEPENDENCIES);
+  it("should generate tab project scoped to groupchat and team", async () => {
+    await helpers
+      .run(testHelper.GENERATOR_PATH)
+      .inDir(testHelper.TEMP_TAB_GENERATOR_PATH + "/tab06")
+      .withArguments(["--no-telemetry"])
+      .withPrompts({
+        solutionName: "tab-test-01",
+        whichFolder: "current",
+        name: "tabtest01",
+        developer: "generator teams developer",
+        manifestVersion: "v1.5",
+        parts: "tab",
+        tabScopes: ["team", "groupchat"],
+        tabType: "configurable"
+      })
+      .withGenerators(testHelper.DEPENDENCIES);
 
-        assert.fileContent(".env", "APPINSIGHTS_INSTRUMENTATIONKEY=");
-        assert.noFileContent("package.json", `"applicationinsights": "^1.3.1"`);
-        assert.noFileContent("src/app/web/index.html", `var appInsights = window.appInsights`);
+    assert.jsonFileContent("src/manifest/manifest.json", {
+      configurableTabs: [
+        {
+          scopes: ["team", "groupchat"]
+        }
+      ]
     });
-
-    it('should generate tab project scoped to groupchat only', async () => {
-        await helpers.run(testHelper.GENERATOR_PATH)
-            .inDir(testHelper.TEMP_TAB_GENERATOR_PATH + '/tab06')
-            .withArguments(['--no-telemetry'])
-            .withPrompts({
-                solutionName: 'tab-test-01',
-                whichFolder: 'current',
-                name: 'tabtest01',
-                developer: 'generator teams developer',
-                manifestVersion: 'v1.5',
-                parts: 'tab',
-                tabScopes: ["groupchat"],
-                tabType: "configurable"
-            })
-            .withGenerators(testHelper.DEPENDENCIES);
-
-        assert.jsonFileContent('src/manifest/manifest.json', {
-            configurableTabs: [
-                {
-                    scopes: ["groupchat"]
-                }
-            ]
-        });
-    });
-
-    it('should generate tab project scoped to team only', async () => {
-        await helpers.run(testHelper.GENERATOR_PATH)
-            .inDir(testHelper.TEMP_TAB_GENERATOR_PATH + '/tab06')
-            .withArguments(['--no-telemetry'])
-            .withPrompts({
-                solutionName: 'tab-test-01',
-                whichFolder: 'current',
-                name: 'tabtest01',
-                developer: 'generator teams developer',
-                manifestVersion: 'v1.5',
-                parts: 'tab',
-                tabScopes: ["team"],
-                tabType: "configurable"
-            })
-            .withGenerators(testHelper.DEPENDENCIES);
-
-        assert.jsonFileContent('src/manifest/manifest.json', {
-            configurableTabs: [
-                {
-                    scopes: ["team"]
-                }
-            ]
-        });
-    });
-    it('should generate tab project scoped to groupchat and team', async () => {
-        await helpers.run(testHelper.GENERATOR_PATH)
-            .inDir(testHelper.TEMP_TAB_GENERATOR_PATH + '/tab06')
-            .withArguments(['--no-telemetry'])
-            .withPrompts({
-                solutionName: 'tab-test-01',
-                whichFolder: 'current',
-                name: 'tabtest01',
-                developer: 'generator teams developer',
-                manifestVersion: 'v1.5',
-                parts: 'tab',
-                tabScopes: ["team", "groupchat"],
-                tabType: "configurable"
-            })
-            .withGenerators(testHelper.DEPENDENCIES);
-
-        assert.jsonFileContent('src/manifest/manifest.json', {
-            configurableTabs: [
-                {
-                    scopes: ["team", "groupchat"]
-                }
-            ]
-        });
-    });
+  });
 });


### PR DESCRIPTION
**PoC Integration Tests: Testing for the compilation of generated projects:**

I categorised the tests as unit tests and integration tests (with mocha grep feature). if you run the command `npm run test-integration` the project will be via. yeoman generated and firstly `npm install` command and then `npm run build` command will be in the generated project executed. there by we can test it whether the project physically can be compiled. The build pipeline can be configured that the `npm run test-integration` command can be executed only via. nightly builds. i also try to use the ts-morph approach but i find this option much better.

@wictorwilen @andrewconnell it would be great if you can give me feedback about this feature 