### PR TITLE
Completion of implementing integration tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "resolved": "https://registry.npmjs.org/@dsherret/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
       "integrity": "sha1-H2R13IvZdM6gei2vOGSzF7HdMyw=",
       "requires": {
-        "is-absolute": "^1.0.0",
-        "is-negated-glob": "^1.0.0"
+        "is-absolute": "1.0.0",
+        "is-negated-glob": "1.0.0"
       }
     },
     "@mrmlnc/readdir-enhanced": {
@@ -18,8 +18,8 @@
       "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
       "integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
       "requires": {
-        "call-me-maybe": "^1.0.1",
-        "glob-to-regexp": "^0.3.0"
+        "call-me-maybe": "1.0.1",
+        "glob-to-regexp": "0.3.0"
       }
     },
     "@nodelib/fs.stat": {
@@ -51,9 +51,9 @@
       "integrity": "sha512-bKCMKZvWIjYD0BLGnNrxVuw4dkWCYsLqFOUWw8VgKF/+5Y+mE7LfHWPIYoDXowH+3a9LsWDMo0uAP8YDosPvHQ==",
       "dev": true,
       "requires": {
-        "@sinonjs/commons": "^1.3.0",
-        "array-from": "^2.1.1",
-        "lodash": "^4.17.15"
+        "@sinonjs/commons": "1.7.1",
+        "array-from": "2.1.1",
+        "lodash": "4.17.15"
       }
     },
     "@sinonjs/text-encoding": {
@@ -68,7 +68,7 @@
       "integrity": "sha512-LDE5atstX5kKnTobWknpmGHC52DH/tp8pIVsD2SSxaOFqW3AQr0EpdzYIfkZ331xe7l9Vn9NlJsBG6viU3mjBA==",
       "dev": true,
       "requires": {
-        "del": "*"
+        "del": "4.1.1"
       }
     },
     "@types/events": {
@@ -83,7 +83,7 @@
       "integrity": "sha512-AInn5+UBFIK9FK5xc9yP5e3TQSPNNgjHByqYcj9g5elVBnDQcQL7PlO1CIRy2gWlbwK7UPYqi7vRvFA44dCmYQ==",
       "dev": true,
       "requires": {
-        "@types/node": "*"
+        "@types/node": "13.7.7"
       }
     },
     "@types/glob": {
@@ -92,9 +92,9 @@
       "integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
       "dev": true,
       "requires": {
-        "@types/events": "*",
-        "@types/minimatch": "*",
-        "@types/node": "*"
+        "@types/events": "3.0.0",
+        "@types/minimatch": "3.0.3",
+        "@types/node": "13.7.7"
       }
     },
     "@types/inquirer": {
@@ -103,8 +103,8 @@
       "integrity": "sha512-rjaYQ9b9y/VFGOpqBEXRavc3jh0a+e6evAbI31tMda8VlPaSy0AZJfXsvmIe3wklc7W6C3zCSfleuMXR7NOyXw==",
       "dev": true,
       "requires": {
-        "@types/through": "*",
-        "rxjs": "^6.4.0"
+        "@types/through": "0.0.30",
+        "rxjs": "6.5.4"
       }
     },
     "@types/lodash": {
@@ -137,7 +137,7 @@
       "integrity": "sha512-SbRnR2S0/CL9GW5mKng/V9T3uEPFSkGC5a71AcyCnT1ltK/kSv1A0nSO8AYI3FjuE4ep04HPi6eCuXWpnwD5HQ==",
       "dev": true,
       "requires": {
-        "@types/node": "*"
+        "@types/node": "13.7.7"
       }
     },
     "@types/semver": {
@@ -152,7 +152,7 @@
       "integrity": "sha512-FvnCJljyxhPM3gkRgWmxmDZyAQSiBQQWLI0A0VFL0K7W1oRUrPJSqNO0NvTnLkBcotdlp3lKvaT0JrnyRDkzOg==",
       "dev": true,
       "requires": {
-        "@types/node": "*"
+        "@types/node": "13.7.7"
       }
     },
     "@types/uuid": {
@@ -179,8 +179,8 @@
       "integrity": "sha512-5oG9Qlk119qSHQpSClGonDIs4djxZSPurtg6faHItjeg8cffhkKs4twVYE+Wa0crAKJZDOwSd/Vmc6BSqJtgMA==",
       "dev": true,
       "requires": {
-        "@types/inquirer": "*",
-        "rxjs": ">=6.4.0"
+        "@types/inquirer": "6.5.0",
+        "rxjs": "6.5.4"
       }
     },
     "@types/yeoman-test": {
@@ -189,7 +189,7 @@
       "integrity": "sha512-aeRSIs1wk9DURLIwfD+0/JOEBSYU7oBjYNIQcYnuU5xLidT+CgDHyMvySwIe4BKSS7eZnP2qpg00QGG5f9YqPA==",
       "dev": true,
       "requires": {
-        "@types/yeoman-generator": "*"
+        "@types/yeoman-generator": "3.1.4"
       }
     },
     "@types/yosay": {
@@ -249,7 +249,7 @@
       "dev": true,
       "requires": {
         "@webassemblyjs/ast": "1.8.5",
-        "mamacro": "^0.0.3"
+        "mamacro": "0.0.3"
       }
     },
     "@webassemblyjs/helper-wasm-bytecode": {
@@ -276,7 +276,7 @@
       "integrity": "sha512-aaCvQYrvKbY/n6wKHb/ylAJr27GglahUO89CcGXMItrOBqRarUMxWLJgxm9PJNuKULwN5n1csT9bYoMeZOGF3g==",
       "dev": true,
       "requires": {
-        "@xtuc/ieee754": "^1.2.0"
+        "@xtuc/ieee754": "1.2.0"
       }
     },
     "@webassemblyjs/leb128": {
@@ -398,10 +398,10 @@
       "integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
       "dev": true,
       "requires": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
+        "fast-deep-equal": "3.1.1",
+        "fast-json-stable-stringify": "2.1.0",
+        "json-schema-traverse": "0.4.1",
+        "uri-js": "4.2.2"
       }
     },
     "ajv-errors": {
@@ -437,7 +437,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "requires": {
-        "color-convert": "^1.9.0"
+        "color-convert": "1.9.3"
       }
     },
     "anymatch": {
@@ -446,8 +446,8 @@
       "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
       "dev": true,
       "requires": {
-        "micromatch": "^3.1.4",
-        "normalize-path": "^2.1.1"
+        "micromatch": "3.1.10",
+        "normalize-path": "2.1.1"
       },
       "dependencies": {
         "normalize-path": {
@@ -456,7 +456,7 @@
           "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
           "dev": true,
           "requires": {
-            "remove-trailing-separator": "^1.0.1"
+            "remove-trailing-separator": "1.1.0"
           }
         }
       }
@@ -466,10 +466,10 @@
       "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-1.7.2.tgz",
       "integrity": "sha512-AtofsH08vrGTMDwXVK6+1wITd8ou9gksFV95JLZo7lVL0wX7/W1qeAZ13DK/6P3VJVsSMJ0sjdVNn98C4XxGvw==",
       "requires": {
-        "cls-hooked": "^4.2.2",
-        "continuation-local-storage": "^3.2.1",
+        "cls-hooked": "4.2.2",
+        "continuation-local-storage": "3.2.1",
         "diagnostic-channel": "0.2.0",
-        "diagnostic-channel-publishers": "^0.3.3"
+        "diagnostic-channel-publishers": "0.3.3"
       }
     },
     "aproba": {
@@ -490,7 +490,7 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
-        "sprintf-js": "~1.0.2"
+        "sprintf-js": "1.0.3"
       }
     },
     "arr-diff": {
@@ -524,7 +524,7 @@
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "requires": {
-        "array-uniq": "^1.0.1"
+        "array-uniq": "1.0.3"
       }
     },
     "array-uniq": {
@@ -548,9 +548,9 @@
       "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
       "dev": true,
       "requires": {
-        "bn.js": "^4.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0"
+        "bn.js": "4.11.8",
+        "inherits": "2.0.4",
+        "minimalistic-assert": "1.0.1"
       }
     },
     "assert": {
@@ -559,7 +559,7 @@
       "integrity": "sha512-EDsgawzwoun2CZkCgtxJbv392v4nbk9XDD06zI+kQYoBM/3RBWLlEyJARDOmhAAosBjWACEkKL6S+lIZtcAubA==",
       "dev": true,
       "requires": {
-        "object-assign": "^4.1.1",
+        "object-assign": "4.1.1",
         "util": "0.10.3"
       },
       "dependencies": {
@@ -596,7 +596,7 @@
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
       "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
       "requires": {
-        "lodash": "^4.17.14"
+        "lodash": "4.17.15"
       }
     },
     "async-each": {
@@ -610,7 +610,7 @@
       "resolved": "https://registry.npmjs.org/async-hook-jl/-/async-hook-jl-1.7.6.tgz",
       "integrity": "sha512-gFaHkFfSxTjvoxDMYqDuGHlcRyUuamF8s+ZTtJdDzqjws4mCt7v0vuV79/E2Wr2/riMQgtG4/yUtXWs1gZ7JMg==",
       "requires": {
-        "stack-chain": "^1.3.7"
+        "stack-chain": "1.3.7"
       }
     },
     "async-listener": {
@@ -618,8 +618,8 @@
       "resolved": "https://registry.npmjs.org/async-listener/-/async-listener-0.6.10.tgz",
       "integrity": "sha512-gpuo6xOyF4D5DE5WvyqZdPA3NGhiT6Qf07l7DCB0wwDEsLvDIbCr6j9S5aj5Ch96dLace5tXVzWBZkxU/c5ohw==",
       "requires": {
-        "semver": "^5.3.0",
-        "shimmer": "^1.1.0"
+        "semver": "5.7.1",
+        "shimmer": "1.2.1"
       },
       "dependencies": {
         "semver": {
@@ -644,13 +644,13 @@
       "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
       "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
       "requires": {
-        "cache-base": "^1.0.1",
-        "class-utils": "^0.3.5",
-        "component-emitter": "^1.2.1",
-        "define-property": "^1.0.0",
-        "isobject": "^3.0.1",
-        "mixin-deep": "^1.2.0",
-        "pascalcase": "^0.1.1"
+        "cache-base": "1.0.1",
+        "class-utils": "0.3.6",
+        "component-emitter": "1.3.0",
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "mixin-deep": "1.3.2",
+        "pascalcase": "0.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -658,7 +658,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "requires": {
-            "is-descriptor": "^1.0.0"
+            "is-descriptor": "1.0.2"
           }
         },
         "is-accessor-descriptor": {
@@ -666,7 +666,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.3"
           }
         },
         "is-data-descriptor": {
@@ -674,7 +674,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.3"
           }
         },
         "is-descriptor": {
@@ -682,9 +682,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.3"
           }
         }
       }
@@ -739,7 +739,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -748,16 +748,16 @@
       "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
       "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
       "requires": {
-        "arr-flatten": "^1.1.0",
-        "array-unique": "^0.3.2",
-        "extend-shallow": "^2.0.1",
-        "fill-range": "^4.0.0",
-        "isobject": "^3.0.1",
-        "repeat-element": "^1.1.2",
-        "snapdragon": "^0.8.1",
-        "snapdragon-node": "^2.0.1",
-        "split-string": "^3.0.2",
-        "to-regex": "^3.0.1"
+        "arr-flatten": "1.1.0",
+        "array-unique": "0.3.2",
+        "extend-shallow": "2.0.1",
+        "fill-range": "4.0.0",
+        "isobject": "3.0.1",
+        "repeat-element": "1.1.3",
+        "snapdragon": "0.8.2",
+        "snapdragon-node": "2.1.1",
+        "split-string": "3.1.0",
+        "to-regex": "3.0.2"
       },
       "dependencies": {
         "extend-shallow": {
@@ -765,7 +765,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         }
       }
@@ -788,12 +788,12 @@
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "dev": true,
       "requires": {
-        "buffer-xor": "^1.0.3",
-        "cipher-base": "^1.0.0",
-        "create-hash": "^1.1.0",
-        "evp_bytestokey": "^1.0.3",
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "buffer-xor": "1.0.3",
+        "cipher-base": "1.0.4",
+        "create-hash": "1.2.0",
+        "evp_bytestokey": "1.0.3",
+        "inherits": "2.0.4",
+        "safe-buffer": "5.2.0"
       }
     },
     "browserify-cipher": {
@@ -802,9 +802,9 @@
       "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
       "dev": true,
       "requires": {
-        "browserify-aes": "^1.0.4",
-        "browserify-des": "^1.0.0",
-        "evp_bytestokey": "^1.0.0"
+        "browserify-aes": "1.2.0",
+        "browserify-des": "1.0.2",
+        "evp_bytestokey": "1.0.3"
       }
     },
     "browserify-des": {
@@ -813,10 +813,10 @@
       "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
       "dev": true,
       "requires": {
-        "cipher-base": "^1.0.1",
-        "des.js": "^1.0.0",
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.1.2"
+        "cipher-base": "1.0.4",
+        "des.js": "1.0.1",
+        "inherits": "2.0.4",
+        "safe-buffer": "5.2.0"
       }
     },
     "browserify-rsa": {
@@ -825,8 +825,8 @@
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
-        "bn.js": "^4.1.0",
-        "randombytes": "^2.0.1"
+        "bn.js": "4.11.8",
+        "randombytes": "2.1.0"
       }
     },
     "browserify-sign": {
@@ -835,13 +835,13 @@
       "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
       "dev": true,
       "requires": {
-        "bn.js": "^4.1.1",
-        "browserify-rsa": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "create-hmac": "^1.1.2",
-        "elliptic": "^6.0.0",
-        "inherits": "^2.0.1",
-        "parse-asn1": "^5.0.0"
+        "bn.js": "4.11.8",
+        "browserify-rsa": "4.0.1",
+        "create-hash": "1.2.0",
+        "create-hmac": "1.1.7",
+        "elliptic": "6.5.2",
+        "inherits": "2.0.4",
+        "parse-asn1": "5.1.5"
       }
     },
     "browserify-zlib": {
@@ -850,7 +850,7 @@
       "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
       "dev": true,
       "requires": {
-        "pako": "~1.0.5"
+        "pako": "1.0.11"
       }
     },
     "buffer": {
@@ -859,9 +859,9 @@
       "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
       "dev": true,
       "requires": {
-        "base64-js": "^1.0.2",
-        "ieee754": "^1.1.4",
-        "isarray": "^1.0.0"
+        "base64-js": "1.3.1",
+        "ieee754": "1.1.13",
+        "isarray": "1.0.0"
       }
     },
     "buffer-alloc": {
@@ -869,8 +869,8 @@
       "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
       "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
       "requires": {
-        "buffer-alloc-unsafe": "^1.1.0",
-        "buffer-fill": "^1.0.0"
+        "buffer-alloc-unsafe": "1.1.0",
+        "buffer-fill": "1.0.0"
       }
     },
     "buffer-alloc-unsafe": {
@@ -907,21 +907,21 @@
       "integrity": "sha512-kqdmfXEGFepesTuROHMs3MpFLWrPkSSpRqOw80RCflZXy/khxaArvFrQ7uJxSUduzAufc6G0g1VUCOZXxWavPw==",
       "dev": true,
       "requires": {
-        "bluebird": "^3.5.5",
-        "chownr": "^1.1.1",
-        "figgy-pudding": "^3.5.1",
-        "glob": "^7.1.4",
-        "graceful-fs": "^4.1.15",
-        "infer-owner": "^1.0.3",
-        "lru-cache": "^5.1.1",
-        "mississippi": "^3.0.0",
-        "mkdirp": "^0.5.1",
-        "move-concurrently": "^1.0.1",
-        "promise-inflight": "^1.0.1",
-        "rimraf": "^2.6.3",
-        "ssri": "^6.0.1",
-        "unique-filename": "^1.1.1",
-        "y18n": "^4.0.0"
+        "bluebird": "3.7.2",
+        "chownr": "1.1.4",
+        "figgy-pudding": "3.5.1",
+        "glob": "7.1.6",
+        "graceful-fs": "4.2.3",
+        "infer-owner": "1.0.4",
+        "lru-cache": "5.1.1",
+        "mississippi": "3.0.0",
+        "mkdirp": "0.5.1",
+        "move-concurrently": "1.0.1",
+        "promise-inflight": "1.0.1",
+        "rimraf": "2.7.1",
+        "ssri": "6.0.1",
+        "unique-filename": "1.1.1",
+        "y18n": "4.0.0"
       },
       "dependencies": {
         "rimraf": {
@@ -930,7 +930,7 @@
           "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
           "dev": true,
           "requires": {
-            "glob": "^7.1.3"
+            "glob": "7.1.6"
           }
         }
       }
@@ -940,15 +940,15 @@
       "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
       "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
       "requires": {
-        "collection-visit": "^1.0.0",
-        "component-emitter": "^1.2.1",
-        "get-value": "^2.0.6",
-        "has-value": "^1.0.0",
-        "isobject": "^3.0.1",
-        "set-value": "^2.0.0",
-        "to-object-path": "^0.3.0",
-        "union-value": "^1.0.0",
-        "unset-value": "^1.0.0"
+        "collection-visit": "1.0.0",
+        "component-emitter": "1.3.0",
+        "get-value": "2.0.6",
+        "has-value": "1.0.0",
+        "isobject": "3.0.1",
+        "set-value": "2.0.1",
+        "to-object-path": "0.3.0",
+        "union-value": "1.0.1",
+        "unset-value": "1.0.0"
       }
     },
     "call-me-maybe": {
@@ -968,12 +968,12 @@
       "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
       "dev": true,
       "requires": {
-        "assertion-error": "^1.1.0",
-        "check-error": "^1.0.2",
-        "deep-eql": "^3.0.1",
-        "get-func-name": "^2.0.0",
-        "pathval": "^1.1.0",
-        "type-detect": "^4.0.5"
+        "assertion-error": "1.1.0",
+        "check-error": "1.0.2",
+        "deep-eql": "3.0.1",
+        "get-func-name": "2.0.0",
+        "pathval": "1.1.0",
+        "type-detect": "4.0.8"
       }
     },
     "chalk": {
@@ -981,9 +981,9 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "requires": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
+        "ansi-styles": "3.2.1",
+        "escape-string-regexp": "1.0.5",
+        "supports-color": "5.5.0"
       }
     },
     "chardet": {
@@ -1003,18 +1003,18 @@
       "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
       "dev": true,
       "requires": {
-        "anymatch": "^2.0.0",
-        "async-each": "^1.0.1",
-        "braces": "^2.3.2",
-        "fsevents": "^1.2.7",
-        "glob-parent": "^3.1.0",
-        "inherits": "^2.0.3",
-        "is-binary-path": "^1.0.0",
-        "is-glob": "^4.0.0",
-        "normalize-path": "^3.0.0",
-        "path-is-absolute": "^1.0.0",
-        "readdirp": "^2.2.1",
-        "upath": "^1.1.1"
+        "anymatch": "2.0.0",
+        "async-each": "1.0.3",
+        "braces": "2.3.2",
+        "fsevents": "1.2.11",
+        "glob-parent": "3.1.0",
+        "inherits": "2.0.4",
+        "is-binary-path": "1.0.1",
+        "is-glob": "4.0.1",
+        "normalize-path": "3.0.0",
+        "path-is-absolute": "1.0.1",
+        "readdirp": "2.2.1",
+        "upath": "1.2.0"
       },
       "dependencies": {
         "is-glob": {
@@ -1023,7 +1023,7 @@
           "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
           "dev": true,
           "requires": {
-            "is-extglob": "^2.1.1"
+            "is-extglob": "2.1.1"
           }
         }
       }
@@ -1040,7 +1040,7 @@
       "integrity": "sha512-9e/zx1jw7B4CO+c/RXoCsfg/x1AfUBioy4owYH0bJprEYAx5hRFLRhWBqHAG57D0ZM4H7vxbP7bPe0VwhQRYDQ==",
       "dev": true,
       "requires": {
-        "tslib": "^1.9.0"
+        "tslib": "1.11.1"
       }
     },
     "cipher-base": {
@@ -1049,8 +1049,8 @@
       "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "2.0.4",
+        "safe-buffer": "5.2.0"
       }
     },
     "class-utils": {
@@ -1058,10 +1058,10 @@
       "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
       "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
       "requires": {
-        "arr-union": "^3.1.0",
-        "define-property": "^0.2.5",
-        "isobject": "^3.0.0",
-        "static-extend": "^0.1.1"
+        "arr-union": "3.1.0",
+        "define-property": "0.2.5",
+        "isobject": "3.0.1",
+        "static-extend": "0.1.2"
       },
       "dependencies": {
         "define-property": {
@@ -1069,7 +1069,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         }
       }
@@ -1080,7 +1080,7 @@
       "integrity": "sha512-pi1111o4OBd9qvacbgs+NRqClfVPKVIc66B4d8kx6Ho/L+i9entQ/NpK600CsTYTPu3kWvKwwyKarsYMvC2xeA==",
       "dev": true,
       "requires": {
-        "del": "^4.0.0"
+        "del": "4.1.1"
       }
     },
     "cli-boxes": {
@@ -1093,7 +1093,7 @@
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "requires": {
-        "restore-cursor": "^2.0.0"
+        "restore-cursor": "2.0.0"
       }
     },
     "cli-table": {
@@ -1115,9 +1115,9 @@
       "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
       "dev": true,
       "requires": {
-        "string-width": "^3.1.0",
-        "strip-ansi": "^5.2.0",
-        "wrap-ansi": "^5.1.0"
+        "string-width": "3.1.0",
+        "strip-ansi": "5.2.0",
+        "wrap-ansi": "5.1.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -1132,9 +1132,9 @@
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
+            "emoji-regex": "7.0.3",
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "5.2.0"
           }
         },
         "strip-ansi": {
@@ -1143,7 +1143,7 @@
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^4.1.0"
+            "ansi-regex": "4.1.0"
           }
         },
         "wrap-ansi": {
@@ -1152,9 +1152,9 @@
           "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.0",
-            "string-width": "^3.0.0",
-            "strip-ansi": "^5.0.0"
+            "ansi-styles": "3.2.1",
+            "string-width": "3.1.0",
+            "strip-ansi": "5.2.0"
           }
         }
       }
@@ -1179,9 +1179,9 @@
       "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.3.tgz",
       "integrity": "sha512-2EF8zTQOxYq70Y4XKtorQupqF0m49MBz2/yf5Bj+MHjvpG3Hy7sImifnqD6UA+TKYxeSV+u6qqQPawN5UvnpKQ==",
       "requires": {
-        "inherits": "^2.0.1",
-        "process-nextick-args": "^2.0.0",
-        "readable-stream": "^2.3.5"
+        "inherits": "2.0.4",
+        "process-nextick-args": "2.0.1",
+        "readable-stream": "2.3.7"
       }
     },
     "cls-hooked": {
@@ -1189,9 +1189,9 @@
       "resolved": "https://registry.npmjs.org/cls-hooked/-/cls-hooked-4.2.2.tgz",
       "integrity": "sha512-J4Xj5f5wq/4jAvcdgoGsL3G103BtWpZrMo8NEinRltN+xpTZdI+M38pyQqhuFU/P792xkMFvnKSf+Lm81U1bxw==",
       "requires": {
-        "async-hook-jl": "^1.7.6",
-        "emitter-listener": "^1.0.1",
-        "semver": "^5.4.1"
+        "async-hook-jl": "1.7.6",
+        "emitter-listener": "1.1.2",
+        "semver": "5.7.1"
       },
       "dependencies": {
         "semver": {
@@ -1216,8 +1216,8 @@
       "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "requires": {
-        "map-visit": "^1.0.0",
-        "object-visit": "^1.0.0"
+        "map-visit": "1.0.0",
+        "object-visit": "1.0.1"
       }
     },
     "color-convert": {
@@ -1265,10 +1265,10 @@
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "dev": true,
       "requires": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
+        "buffer-from": "1.1.1",
+        "inherits": "2.0.4",
+        "readable-stream": "2.3.7",
+        "typedarray": "0.0.6"
       }
     },
     "console-browserify": {
@@ -1288,8 +1288,8 @@
       "resolved": "https://registry.npmjs.org/continuation-local-storage/-/continuation-local-storage-3.2.1.tgz",
       "integrity": "sha512-jx44cconVqkCEEyLSKWwkvUXwO561jXMa3LPjTPsm5QR22PA0/mhe33FT4Xb5y74JDvt/Cq+5lm8S8rskLv9ZA==",
       "requires": {
-        "async-listener": "^0.6.0",
-        "emitter-listener": "^1.1.1"
+        "async-listener": "0.6.10",
+        "emitter-listener": "1.1.2"
       }
     },
     "copy-concurrently": {
@@ -1298,12 +1298,12 @@
       "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
       "dev": true,
       "requires": {
-        "aproba": "^1.1.1",
-        "fs-write-stream-atomic": "^1.0.8",
-        "iferr": "^0.1.5",
-        "mkdirp": "^0.5.1",
-        "rimraf": "^2.5.4",
-        "run-queue": "^1.0.0"
+        "aproba": "1.2.0",
+        "fs-write-stream-atomic": "1.0.10",
+        "iferr": "0.1.5",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.7.1",
+        "run-queue": "1.0.3"
       },
       "dependencies": {
         "rimraf": {
@@ -1312,7 +1312,7 @@
           "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
           "dev": true,
           "requires": {
-            "glob": "^7.1.3"
+            "glob": "7.1.6"
           }
         }
       }
@@ -1328,18 +1328,18 @@
       "integrity": "sha512-P15M5ZC8dyCjQHWwd4Ia/dm0SgVvZJMYeykVIVYXbGyqO4dWB5oyPHp9i7wjwo5LhtlhKbiBCdS2NvM07Wlybg==",
       "dev": true,
       "requires": {
-        "cacache": "^12.0.3",
-        "find-cache-dir": "^2.1.0",
-        "glob-parent": "^3.1.0",
-        "globby": "^7.1.1",
-        "is-glob": "^4.0.1",
-        "loader-utils": "^1.2.3",
-        "minimatch": "^3.0.4",
-        "normalize-path": "^3.0.0",
-        "p-limit": "^2.2.1",
-        "schema-utils": "^1.0.0",
-        "serialize-javascript": "^2.1.2",
-        "webpack-log": "^2.0.0"
+        "cacache": "12.0.3",
+        "find-cache-dir": "2.1.0",
+        "glob-parent": "3.1.0",
+        "globby": "7.1.1",
+        "is-glob": "4.0.1",
+        "loader-utils": "1.4.0",
+        "minimatch": "3.0.4",
+        "normalize-path": "3.0.0",
+        "p-limit": "2.2.2",
+        "schema-utils": "1.0.0",
+        "serialize-javascript": "2.1.2",
+        "webpack-log": "2.0.0"
       },
       "dependencies": {
         "globby": {
@@ -1348,12 +1348,12 @@
           "integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
           "dev": true,
           "requires": {
-            "array-union": "^1.0.1",
-            "dir-glob": "^2.0.0",
-            "glob": "^7.1.2",
-            "ignore": "^3.3.5",
-            "pify": "^3.0.0",
-            "slash": "^1.0.0"
+            "array-union": "1.0.2",
+            "dir-glob": "2.0.0",
+            "glob": "7.1.6",
+            "ignore": "3.3.10",
+            "pify": "3.0.0",
+            "slash": "1.0.0"
           }
         },
         "is-glob": {
@@ -1362,7 +1362,7 @@
           "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
           "dev": true,
           "requires": {
-            "is-extglob": "^2.1.1"
+            "is-extglob": "2.1.1"
           }
         }
       }
@@ -1378,8 +1378,8 @@
       "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
       "dev": true,
       "requires": {
-        "bn.js": "^4.1.0",
-        "elliptic": "^6.0.0"
+        "bn.js": "4.11.8",
+        "elliptic": "6.5.2"
       }
     },
     "create-hash": {
@@ -1388,11 +1388,11 @@
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "dev": true,
       "requires": {
-        "cipher-base": "^1.0.1",
-        "inherits": "^2.0.1",
-        "md5.js": "^1.3.4",
-        "ripemd160": "^2.0.1",
-        "sha.js": "^2.4.0"
+        "cipher-base": "1.0.4",
+        "inherits": "2.0.4",
+        "md5.js": "1.3.5",
+        "ripemd160": "2.0.2",
+        "sha.js": "2.4.11"
       }
     },
     "create-hmac": {
@@ -1401,12 +1401,64 @@
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "dev": true,
       "requires": {
-        "cipher-base": "^1.0.3",
-        "create-hash": "^1.1.0",
-        "inherits": "^2.0.1",
-        "ripemd160": "^2.0.0",
-        "safe-buffer": "^5.0.1",
-        "sha.js": "^2.4.8"
+        "cipher-base": "1.0.4",
+        "create-hash": "1.2.0",
+        "inherits": "2.0.4",
+        "ripemd160": "2.0.2",
+        "safe-buffer": "5.2.0",
+        "sha.js": "2.4.11"
+      }
+    },
+    "cross-env": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.2.tgz",
+      "integrity": "sha512-KZP/bMEOJEDCkDQAyRhu3RL2ZO/SUVrxQVI0G3YEQ+OLbRA3c6zgixe8Mq8a/z7+HKlNEjo8oiLUs8iRijY2Rw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "7.0.1"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.1.tgz",
+          "integrity": "sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==",
+          "dev": true,
+          "requires": {
+            "path-key": "3.1.1",
+            "shebang-command": "2.0.0",
+            "which": "2.0.2"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "2.0.0"
+          }
+        }
       }
     },
     "cross-spawn": {
@@ -1414,11 +1466,11 @@
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
       "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
       "requires": {
-        "nice-try": "^1.0.4",
-        "path-key": "^2.0.1",
-        "semver": "^5.5.0",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
+        "nice-try": "1.0.5",
+        "path-key": "2.0.1",
+        "semver": "5.7.1",
+        "shebang-command": "1.2.0",
+        "which": "1.3.1"
       },
       "dependencies": {
         "semver": {
@@ -1434,17 +1486,17 @@
       "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
       "dev": true,
       "requires": {
-        "browserify-cipher": "^1.0.0",
-        "browserify-sign": "^4.0.0",
-        "create-ecdh": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "create-hmac": "^1.1.0",
-        "diffie-hellman": "^5.0.0",
-        "inherits": "^2.0.1",
-        "pbkdf2": "^3.0.3",
-        "public-encrypt": "^4.0.0",
-        "randombytes": "^2.0.0",
-        "randomfill": "^1.0.3"
+        "browserify-cipher": "1.0.1",
+        "browserify-sign": "4.0.4",
+        "create-ecdh": "4.0.3",
+        "create-hash": "1.2.0",
+        "create-hmac": "1.1.7",
+        "diffie-hellman": "5.0.3",
+        "inherits": "2.0.4",
+        "pbkdf2": "3.0.17",
+        "public-encrypt": "4.0.3",
+        "randombytes": "2.1.0",
+        "randomfill": "1.0.4"
       }
     },
     "cyclist": {
@@ -1487,7 +1539,7 @@
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
       "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
       "requires": {
-        "mimic-response": "^1.0.0"
+        "mimic-response": "1.0.1"
       }
     },
     "deep-eql": {
@@ -1496,7 +1548,7 @@
       "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
       "dev": true,
       "requires": {
-        "type-detect": "^4.0.0"
+        "type-detect": "4.0.8"
       }
     },
     "deep-extend": {
@@ -1510,7 +1562,7 @@
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
       "dev": true,
       "requires": {
-        "object-keys": "^1.0.12"
+        "object-keys": "1.1.1"
       }
     },
     "define-property": {
@@ -1518,8 +1570,8 @@
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
       "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
       "requires": {
-        "is-descriptor": "^1.0.2",
-        "isobject": "^3.0.1"
+        "is-descriptor": "1.0.2",
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "is-accessor-descriptor": {
@@ -1527,7 +1579,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.3"
           }
         },
         "is-data-descriptor": {
@@ -1535,7 +1587,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.3"
           }
         },
         "is-descriptor": {
@@ -1543,9 +1595,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.3"
           }
         }
       }
@@ -1556,13 +1608,13 @@
       "integrity": "sha512-QwGuEUouP2kVwQenAsOof5Fv8K9t3D8Ca8NxcXKrIpEHjTXK5J2nXLdP+ALI1cgv8wj7KuwBhTwBkOZSJKM5XQ==",
       "dev": true,
       "requires": {
-        "@types/glob": "^7.1.1",
-        "globby": "^6.1.0",
-        "is-path-cwd": "^2.0.0",
-        "is-path-in-cwd": "^2.0.0",
-        "p-map": "^2.0.0",
-        "pify": "^4.0.1",
-        "rimraf": "^2.6.3"
+        "@types/glob": "7.1.1",
+        "globby": "6.1.0",
+        "is-path-cwd": "2.2.0",
+        "is-path-in-cwd": "2.1.0",
+        "p-map": "2.1.0",
+        "pify": "4.0.1",
+        "rimraf": "2.7.1"
       },
       "dependencies": {
         "globby": {
@@ -1571,11 +1623,11 @@
           "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
           "dev": true,
           "requires": {
-            "array-union": "^1.0.1",
-            "glob": "^7.0.3",
-            "object-assign": "^4.0.1",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "array-union": "1.0.2",
+            "glob": "7.1.6",
+            "object-assign": "4.1.1",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
           },
           "dependencies": {
             "pify": {
@@ -1598,7 +1650,7 @@
           "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
           "dev": true,
           "requires": {
-            "glob": "^7.1.3"
+            "glob": "7.1.6"
           }
         }
       }
@@ -1609,8 +1661,8 @@
       "integrity": "sha512-Q0I4pfFrv2VPd34/vfLrFOoRmlYj3OV50i7fskps1jZWK1kApMWWT9G6RRUeYedLcBDIhnSDaUvJMb3AhUlaEA==",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0"
+        "inherits": "2.0.4",
+        "minimalistic-assert": "1.0.1"
       }
     },
     "detect-conflict": {
@@ -1629,7 +1681,7 @@
       "resolved": "https://registry.npmjs.org/diagnostic-channel/-/diagnostic-channel-0.2.0.tgz",
       "integrity": "sha1-zJmvlhLCP7H/8TYSxy8sv6qNWhc=",
       "requires": {
-        "semver": "^5.3.0"
+        "semver": "5.7.1"
       },
       "dependencies": {
         "semver": {
@@ -1655,9 +1707,9 @@
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "dev": true,
       "requires": {
-        "bn.js": "^4.1.0",
-        "miller-rabin": "^4.0.0",
-        "randombytes": "^2.0.0"
+        "bn.js": "4.11.8",
+        "miller-rabin": "4.0.1",
+        "randombytes": "2.1.0"
       }
     },
     "dir-glob": {
@@ -1665,8 +1717,8 @@
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
       "integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
       "requires": {
-        "arrify": "^1.0.1",
-        "path-type": "^3.0.0"
+        "arrify": "1.0.1",
+        "path-type": "3.0.0"
       }
     },
     "domain-browser": {
@@ -1691,10 +1743,10 @@
       "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
       "dev": true,
       "requires": {
-        "end-of-stream": "^1.0.0",
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.0",
-        "stream-shift": "^1.0.0"
+        "end-of-stream": "1.4.4",
+        "inherits": "2.0.4",
+        "readable-stream": "2.3.7",
+        "stream-shift": "1.0.1"
       }
     },
     "editions": {
@@ -1702,8 +1754,8 @@
       "resolved": "https://registry.npmjs.org/editions/-/editions-2.3.0.tgz",
       "integrity": "sha512-jeXYwHPKbitU1l14dWlsl5Nm+b1Hsm7VX73BsrQ4RVwEcAQQIPFHTZAbVtuIGxZBrpdT2FXd8lbtrNBrzZxIsA==",
       "requires": {
-        "errlop": "^2.0.0",
-        "semver": "^6.3.0"
+        "errlop": "2.0.0",
+        "semver": "6.3.0"
       }
     },
     "ejs": {
@@ -1717,13 +1769,13 @@
       "integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
       "dev": true,
       "requires": {
-        "bn.js": "^4.4.0",
-        "brorand": "^1.0.1",
-        "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.0"
+        "bn.js": "4.11.8",
+        "brorand": "1.1.0",
+        "hash.js": "1.1.7",
+        "hmac-drbg": "1.0.1",
+        "inherits": "2.0.4",
+        "minimalistic-assert": "1.0.1",
+        "minimalistic-crypto-utils": "1.0.1"
       }
     },
     "emitter-listener": {
@@ -1731,7 +1783,7 @@
       "resolved": "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.1.2.tgz",
       "integrity": "sha512-Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==",
       "requires": {
-        "shimmer": "^1.2.0"
+        "shimmer": "1.2.1"
       }
     },
     "emoji-regex": {
@@ -1752,7 +1804,7 @@
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "dev": true,
       "requires": {
-        "once": "^1.4.0"
+        "once": "1.4.0"
       }
     },
     "enhanced-resolve": {
@@ -1761,9 +1813,9 @@
       "integrity": "sha512-98p2zE+rL7/g/DzMHMTF4zZlCgeVdJ7yr6xzEpJRYwFYrGi9ANdn5DnJURg6RpBkyk60XYDnWIv51VfIhfNGuA==",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "memory-fs": "^0.5.0",
-        "tapable": "^1.0.0"
+        "graceful-fs": "4.2.3",
+        "memory-fs": "0.5.0",
+        "tapable": "1.1.3"
       }
     },
     "errlop": {
@@ -1777,7 +1829,7 @@
       "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
       "dev": true,
       "requires": {
-        "prr": "~1.0.1"
+        "prr": "1.0.1"
       }
     },
     "error": {
@@ -1785,7 +1837,7 @@
       "resolved": "https://registry.npmjs.org/error/-/error-7.2.1.tgz",
       "integrity": "sha512-fo9HBvWnx3NGUKMvMwB/CBCMMrfEJgbDTVDEkPygA3Bdd3lM1OyCd+rbQ8BwnpF6GdVeOLDNmyL4N5Bg80ZvdA==",
       "requires": {
-        "string-template": "~0.2.1"
+        "string-template": "0.2.1"
       }
     },
     "error-ex": {
@@ -1793,7 +1845,7 @@
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "requires": {
-        "is-arrayish": "^0.2.1"
+        "is-arrayish": "0.2.1"
       }
     },
     "es-abstract": {
@@ -1802,17 +1854,17 @@
       "integrity": "sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==",
       "dev": true,
       "requires": {
-        "es-to-primitive": "^1.2.1",
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.1",
-        "is-callable": "^1.1.5",
-        "is-regex": "^1.0.5",
-        "object-inspect": "^1.7.0",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.0",
-        "string.prototype.trimleft": "^2.1.1",
-        "string.prototype.trimright": "^2.1.1"
+        "es-to-primitive": "1.2.1",
+        "function-bind": "1.1.1",
+        "has": "1.0.3",
+        "has-symbols": "1.0.1",
+        "is-callable": "1.1.5",
+        "is-regex": "1.0.5",
+        "object-inspect": "1.7.0",
+        "object-keys": "1.1.1",
+        "object.assign": "4.1.0",
+        "string.prototype.trimleft": "2.1.1",
+        "string.prototype.trimright": "2.1.1"
       }
     },
     "es-to-primitive": {
@@ -1821,9 +1873,9 @@
       "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
       "dev": true,
       "requires": {
-        "is-callable": "^1.1.4",
-        "is-date-object": "^1.0.1",
-        "is-symbol": "^1.0.2"
+        "is-callable": "1.1.5",
+        "is-date-object": "1.0.2",
+        "is-symbol": "1.0.3"
       }
     },
     "escape-string-regexp": {
@@ -1837,8 +1889,8 @@
       "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
       "dev": true,
       "requires": {
-        "esrecurse": "^4.1.0",
-        "estraverse": "^4.1.1"
+        "esrecurse": "4.2.1",
+        "estraverse": "4.3.0"
       }
     },
     "esprima": {
@@ -1853,7 +1905,7 @@
       "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
       "dev": true,
       "requires": {
-        "estraverse": "^4.1.0"
+        "estraverse": "4.3.0"
       }
     },
     "estraverse": {
@@ -1874,8 +1926,8 @@
       "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
       "dev": true,
       "requires": {
-        "md5.js": "^1.3.4",
-        "safe-buffer": "^5.1.1"
+        "md5.js": "1.3.5",
+        "safe-buffer": "5.2.0"
       }
     },
     "execa": {
@@ -1884,13 +1936,13 @@
       "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
       "dev": true,
       "requires": {
-        "cross-spawn": "^6.0.0",
-        "get-stream": "^4.0.0",
-        "is-stream": "^1.1.0",
-        "npm-run-path": "^2.0.0",
-        "p-finally": "^1.0.0",
-        "signal-exit": "^3.0.0",
-        "strip-eof": "^1.0.0"
+        "cross-spawn": "6.0.5",
+        "get-stream": "4.1.0",
+        "is-stream": "1.1.0",
+        "npm-run-path": "2.0.2",
+        "p-finally": "1.0.0",
+        "signal-exit": "3.0.2",
+        "strip-eof": "1.0.0"
       },
       "dependencies": {
         "get-stream": {
@@ -1899,7 +1951,7 @@
           "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
           "dev": true,
           "requires": {
-            "pump": "^3.0.0"
+            "pump": "3.0.0"
           }
         }
       }
@@ -1909,13 +1961,13 @@
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
       "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
       "requires": {
-        "debug": "^2.3.3",
-        "define-property": "^0.2.5",
-        "extend-shallow": "^2.0.1",
-        "posix-character-classes": "^0.1.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
+        "debug": "2.6.9",
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "posix-character-classes": "0.1.1",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
       },
       "dependencies": {
         "define-property": {
@@ -1923,7 +1975,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "extend-shallow": {
@@ -1931,7 +1983,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         }
       }
@@ -1942,7 +1994,7 @@
       "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
       "dev": true,
       "requires": {
-        "homedir-polyfill": "^1.0.1"
+        "homedir-polyfill": "1.0.3"
       }
     },
     "extend-shallow": {
@@ -1950,8 +2002,8 @@
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "requires": {
-        "assign-symbols": "^1.0.0",
-        "is-extendable": "^1.0.1"
+        "assign-symbols": "1.0.0",
+        "is-extendable": "1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -1959,7 +2011,7 @@
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "requires": {
-            "is-plain-object": "^2.0.4"
+            "is-plain-object": "2.0.4"
           }
         }
       }
@@ -1969,9 +2021,9 @@
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
       "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
       "requires": {
-        "chardet": "^0.7.0",
-        "iconv-lite": "^0.4.24",
-        "tmp": "^0.0.33"
+        "chardet": "0.7.0",
+        "iconv-lite": "0.4.24",
+        "tmp": "0.0.33"
       }
     },
     "extglob": {
@@ -1979,14 +2031,14 @@
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
       "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
       "requires": {
-        "array-unique": "^0.3.2",
-        "define-property": "^1.0.0",
-        "expand-brackets": "^2.1.4",
-        "extend-shallow": "^2.0.1",
-        "fragment-cache": "^0.2.1",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
+        "array-unique": "0.3.2",
+        "define-property": "1.0.0",
+        "expand-brackets": "2.1.4",
+        "extend-shallow": "2.0.1",
+        "fragment-cache": "0.2.1",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
       },
       "dependencies": {
         "define-property": {
@@ -1994,7 +2046,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "requires": {
-            "is-descriptor": "^1.0.0"
+            "is-descriptor": "1.0.2"
           }
         },
         "extend-shallow": {
@@ -2002,7 +2054,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         },
         "is-accessor-descriptor": {
@@ -2010,7 +2062,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.3"
           }
         },
         "is-data-descriptor": {
@@ -2018,7 +2070,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.3"
           }
         },
         "is-descriptor": {
@@ -2026,9 +2078,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.3"
           }
         }
       }
@@ -2044,12 +2096,12 @@
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.7.tgz",
       "integrity": "sha512-g1KuQwHOZAmOZMuBtHdxDtju+T2RT8jgCC9aANsbpdiDDTSnjgfuVsIBNKbUeJI3oKMRExcfNDtJl4OhbffMsw==",
       "requires": {
-        "@mrmlnc/readdir-enhanced": "^2.2.1",
-        "@nodelib/fs.stat": "^1.1.2",
-        "glob-parent": "^3.1.0",
-        "is-glob": "^4.0.0",
-        "merge2": "^1.2.3",
-        "micromatch": "^3.1.10"
+        "@mrmlnc/readdir-enhanced": "2.2.1",
+        "@nodelib/fs.stat": "1.1.3",
+        "glob-parent": "3.1.0",
+        "is-glob": "4.0.1",
+        "merge2": "1.3.0",
+        "micromatch": "3.1.10"
       },
       "dependencies": {
         "is-glob": {
@@ -2057,7 +2109,7 @@
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
           "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
           "requires": {
-            "is-extglob": "^2.1.1"
+            "is-extglob": "2.1.1"
           }
         }
       }
@@ -2079,7 +2131,7 @@
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
       "requires": {
-        "escape-string-regexp": "^1.0.5"
+        "escape-string-regexp": "1.0.5"
       }
     },
     "file-uri-to-path": {
@@ -2094,10 +2146,10 @@
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
       "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
       "requires": {
-        "extend-shallow": "^2.0.1",
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1",
-        "to-regex-range": "^2.1.0"
+        "extend-shallow": "2.0.1",
+        "is-number": "3.0.0",
+        "repeat-string": "1.6.1",
+        "to-regex-range": "2.1.1"
       },
       "dependencies": {
         "extend-shallow": {
@@ -2105,7 +2157,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         }
       }
@@ -2116,9 +2168,9 @@
       "integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
       "dev": true,
       "requires": {
-        "commondir": "^1.0.1",
-        "make-dir": "^2.0.0",
-        "pkg-dir": "^3.0.0"
+        "commondir": "1.0.1",
+        "make-dir": "2.1.0",
+        "pkg-dir": "3.0.0"
       },
       "dependencies": {
         "make-dir": {
@@ -2127,8 +2179,8 @@
           "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
           "dev": true,
           "requires": {
-            "pify": "^4.0.1",
-            "semver": "^5.6.0"
+            "pify": "4.0.1",
+            "semver": "5.7.1"
           }
         },
         "pify": {
@@ -2150,7 +2202,7 @@
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
       "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
       "requires": {
-        "locate-path": "^3.0.0"
+        "locate-path": "3.0.0"
       }
     },
     "findup-sync": {
@@ -2159,10 +2211,10 @@
       "integrity": "sha512-YbffarhcicEhOrm4CtrwdKBdCuz576RLdhJDsIfvNtxUuhdRet1qZcsMjqbePtAseKdAnDyM/IyXbu7PRPRLYg==",
       "dev": true,
       "requires": {
-        "detect-file": "^1.0.0",
-        "is-glob": "^4.0.0",
-        "micromatch": "^3.0.4",
-        "resolve-dir": "^1.0.1"
+        "detect-file": "1.0.0",
+        "is-glob": "4.0.1",
+        "micromatch": "3.1.10",
+        "resolve-dir": "1.0.1"
       },
       "dependencies": {
         "is-glob": {
@@ -2171,7 +2223,7 @@
           "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
           "dev": true,
           "requires": {
-            "is-extglob": "^2.1.1"
+            "is-extglob": "2.1.1"
           }
         }
       }
@@ -2181,7 +2233,7 @@
       "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-2.0.0.tgz",
       "integrity": "sha1-G97NuOCDwGZLkZRVgVd6Q6nzHXA=",
       "requires": {
-        "readable-stream": "^2.0.2"
+        "readable-stream": "2.3.7"
       }
     },
     "flat": {
@@ -2190,7 +2242,7 @@
       "integrity": "sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==",
       "dev": true,
       "requires": {
-        "is-buffer": "~2.0.3"
+        "is-buffer": "2.0.4"
       },
       "dependencies": {
         "is-buffer": {
@@ -2207,8 +2259,8 @@
       "integrity": "sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.3.6"
+        "inherits": "2.0.4",
+        "readable-stream": "2.3.7"
       }
     },
     "for-in": {
@@ -2221,7 +2273,7 @@
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "requires": {
-        "map-cache": "^0.2.2"
+        "map-cache": "0.2.2"
       }
     },
     "from2": {
@@ -2230,8 +2282,8 @@
       "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.0"
+        "inherits": "2.0.4",
+        "readable-stream": "2.3.7"
       }
     },
     "fs-extra": {
@@ -2239,9 +2291,9 @@
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
+        "graceful-fs": "4.2.3",
+        "jsonfile": "4.0.0",
+        "universalify": "0.1.2"
       }
     },
     "fs-write-stream-atomic": {
@@ -2250,10 +2302,10 @@
       "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "iferr": "^0.1.5",
-        "imurmurhash": "^0.1.4",
-        "readable-stream": "1 || 2"
+        "graceful-fs": "4.2.3",
+        "iferr": "0.1.5",
+        "imurmurhash": "0.1.4",
+        "readable-stream": "2.3.7"
       }
     },
     "fs.realpath": {
@@ -2268,9 +2320,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "bindings": "^1.5.0",
-        "nan": "^2.12.1",
-        "node-pre-gyp": "*"
+        "bindings": "1.5.0",
+        "nan": "2.14.0",
+        "node-pre-gyp": "0.14.0"
       },
       "dependencies": {
         "abbrev": {
@@ -2296,8 +2348,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "delegates": "^1.0.0",
-            "readable-stream": "^2.0.6"
+            "delegates": "1.0.0",
+            "readable-stream": "2.3.6"
           }
         },
         "balanced-match": {
@@ -2310,7 +2362,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "balanced-match": "^1.0.0",
+            "balanced-match": "1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -2347,7 +2399,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
         },
         "deep-extend": {
@@ -2374,7 +2426,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.6.0"
+            "minipass": "2.9.0"
           }
         },
         "fs.realpath": {
@@ -2389,14 +2441,14 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "aproba": "^1.0.3",
-            "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
+            "aproba": "1.2.0",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.3"
           }
         },
         "glob": {
@@ -2405,12 +2457,12 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.4",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "has-unicode": {
@@ -2425,7 +2477,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
+            "safer-buffer": "2.1.2"
           }
         },
         "ignore-walk": {
@@ -2434,7 +2486,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minimatch": "^3.0.4"
+            "minimatch": "3.0.4"
           }
         },
         "inflight": {
@@ -2443,8 +2495,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
           }
         },
         "inherits": {
@@ -2463,7 +2515,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "isarray": {
@@ -2477,7 +2529,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "minimist": {
@@ -2490,8 +2542,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.0"
+            "safe-buffer": "5.1.2",
+            "yallist": "3.1.1"
           }
         },
         "minizlib": {
@@ -2500,7 +2552,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.9.0"
+            "minipass": "2.9.0"
           }
         },
         "mkdirp": {
@@ -2523,9 +2575,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "debug": "^3.2.6",
-            "iconv-lite": "^0.4.4",
-            "sax": "^1.2.4"
+            "debug": "3.2.6",
+            "iconv-lite": "0.4.24",
+            "sax": "1.2.4"
           }
         },
         "node-pre-gyp": {
@@ -2534,16 +2586,16 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "detect-libc": "^1.0.2",
-            "mkdirp": "^0.5.1",
-            "needle": "^2.2.1",
-            "nopt": "^4.0.1",
-            "npm-packlist": "^1.1.6",
-            "npmlog": "^4.0.2",
-            "rc": "^1.2.7",
-            "rimraf": "^2.6.1",
-            "semver": "^5.3.0",
-            "tar": "^4.4.2"
+            "detect-libc": "1.0.3",
+            "mkdirp": "0.5.1",
+            "needle": "2.4.0",
+            "nopt": "4.0.1",
+            "npm-packlist": "1.4.7",
+            "npmlog": "4.1.2",
+            "rc": "1.2.8",
+            "rimraf": "2.7.1",
+            "semver": "5.7.1",
+            "tar": "4.4.13"
           }
         },
         "nopt": {
@@ -2552,8 +2604,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
+            "abbrev": "1.1.1",
+            "osenv": "0.1.5"
           }
         },
         "npm-bundled": {
@@ -2562,7 +2614,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "npm-normalize-package-bin": "^1.0.1"
+            "npm-normalize-package-bin": "1.0.1"
           }
         },
         "npm-normalize-package-bin": {
@@ -2577,8 +2629,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1"
+            "ignore-walk": "3.0.3",
+            "npm-bundled": "1.1.1"
           }
         },
         "npmlog": {
@@ -2587,10 +2639,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
+            "are-we-there-yet": "1.1.5",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
           }
         },
         "number-is-nan": {
@@ -2609,7 +2661,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "wrappy": "1"
+            "wrappy": "1.0.2"
           }
         },
         "os-homedir": {
@@ -2630,8 +2682,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
           }
         },
         "path-is-absolute": {
@@ -2652,10 +2704,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "deep-extend": "^0.6.0",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
+            "deep-extend": "0.6.0",
+            "ini": "1.3.5",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
           },
           "dependencies": {
             "minimist": {
@@ -2672,13 +2724,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.4",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.1",
+            "safe-buffer": "5.1.2",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "rimraf": {
@@ -2687,7 +2739,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "glob": "^7.1.3"
+            "glob": "7.1.6"
           }
         },
         "safe-buffer": {
@@ -2730,9 +2782,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         },
         "string_decoder": {
@@ -2741,7 +2793,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.2"
           }
         },
         "strip-ansi": {
@@ -2749,7 +2801,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "strip-json-comments": {
@@ -2764,13 +2816,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "chownr": "^1.1.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.8.6",
-            "minizlib": "^1.2.1",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.3"
+            "chownr": "1.1.3",
+            "fs-minipass": "1.2.7",
+            "minipass": "2.9.0",
+            "minizlib": "1.3.3",
+            "mkdirp": "0.5.1",
+            "safe-buffer": "5.1.2",
+            "yallist": "3.1.1"
           }
         },
         "util-deprecate": {
@@ -2785,7 +2837,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "string-width": "^1.0.2 || 2"
+            "string-width": "1.0.2"
           }
         },
         "wrappy": {
@@ -2838,8 +2890,8 @@
       "resolved": "https://registry.npmjs.org/gh-got/-/gh-got-6.0.0.tgz",
       "integrity": "sha512-F/mS+fsWQMo1zfgG9MD8KWvTWPPzzhuVwY++fhQ5Ggd+0P+CAMHtzMZhNxG+TqGfHDChJKsbh6otfMGqO2AKBw==",
       "requires": {
-        "got": "^7.0.0",
-        "is-plain-obj": "^1.1.0"
+        "got": "7.1.0",
+        "is-plain-obj": "1.1.0"
       }
     },
     "github-username": {
@@ -2847,7 +2899,7 @@
       "resolved": "https://registry.npmjs.org/github-username/-/github-username-4.1.0.tgz",
       "integrity": "sha1-y+KABBiDIG2kISrp5LXxacML9Bc=",
       "requires": {
-        "gh-got": "^6.0.0"
+        "gh-got": "6.0.0"
       }
     },
     "glob": {
@@ -2855,12 +2907,12 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
       "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
       "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.4",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
       }
     },
     "glob-parent": {
@@ -2868,8 +2920,8 @@
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
       "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
       "requires": {
-        "is-glob": "^3.1.0",
-        "path-dirname": "^1.0.0"
+        "is-glob": "3.1.0",
+        "path-dirname": "1.0.2"
       }
     },
     "glob-to-regexp": {
@@ -2883,7 +2935,7 @@
       "integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
       "dev": true,
       "requires": {
-        "global-prefix": "^3.0.0"
+        "global-prefix": "3.0.0"
       },
       "dependencies": {
         "global-prefix": {
@@ -2892,9 +2944,9 @@
           "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
           "dev": true,
           "requires": {
-            "ini": "^1.3.5",
-            "kind-of": "^6.0.2",
-            "which": "^1.3.1"
+            "ini": "1.3.5",
+            "kind-of": "6.0.3",
+            "which": "1.3.1"
           }
         }
       }
@@ -2905,11 +2957,11 @@
       "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
       "dev": true,
       "requires": {
-        "expand-tilde": "^2.0.2",
-        "homedir-polyfill": "^1.0.1",
-        "ini": "^1.3.4",
-        "is-windows": "^1.0.1",
-        "which": "^1.2.14"
+        "expand-tilde": "2.0.2",
+        "homedir-polyfill": "1.0.3",
+        "ini": "1.3.5",
+        "is-windows": "1.0.2",
+        "which": "1.3.1"
       }
     },
     "globby": {
@@ -2917,13 +2969,13 @@
       "resolved": "https://registry.npmjs.org/globby/-/globby-8.0.2.tgz",
       "integrity": "sha512-yTzMmKygLp8RUpG1Ymu2VXPSJQZjNAZPD4ywgYEaG7e4tBJeUQBO8OpXrf1RCNcEs5alsoJYPAMiIHP0cmeC7w==",
       "requires": {
-        "array-union": "^1.0.1",
+        "array-union": "1.0.2",
         "dir-glob": "2.0.0",
-        "fast-glob": "^2.0.2",
-        "glob": "^7.1.2",
-        "ignore": "^3.3.5",
-        "pify": "^3.0.0",
-        "slash": "^1.0.0"
+        "fast-glob": "2.2.7",
+        "glob": "7.1.6",
+        "ignore": "3.3.10",
+        "pify": "3.0.0",
+        "slash": "1.0.0"
       }
     },
     "got": {
@@ -2931,20 +2983,20 @@
       "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
       "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
       "requires": {
-        "decompress-response": "^3.2.0",
-        "duplexer3": "^0.1.4",
-        "get-stream": "^3.0.0",
-        "is-plain-obj": "^1.1.0",
-        "is-retry-allowed": "^1.0.0",
-        "is-stream": "^1.0.0",
-        "isurl": "^1.0.0-alpha5",
-        "lowercase-keys": "^1.0.0",
-        "p-cancelable": "^0.3.0",
-        "p-timeout": "^1.1.1",
-        "safe-buffer": "^5.0.1",
-        "timed-out": "^4.0.0",
-        "url-parse-lax": "^1.0.0",
-        "url-to-options": "^1.0.1"
+        "decompress-response": "3.3.0",
+        "duplexer3": "0.1.4",
+        "get-stream": "3.0.0",
+        "is-plain-obj": "1.1.0",
+        "is-retry-allowed": "1.2.0",
+        "is-stream": "1.1.0",
+        "isurl": "1.0.0",
+        "lowercase-keys": "1.0.1",
+        "p-cancelable": "0.3.0",
+        "p-timeout": "1.2.1",
+        "safe-buffer": "5.2.0",
+        "timed-out": "4.0.1",
+        "url-parse-lax": "1.0.0",
+        "url-to-options": "1.0.1"
       }
     },
     "graceful-fs": {
@@ -2957,7 +3009,7 @@
       "resolved": "https://registry.npmjs.org/grouped-queue/-/grouped-queue-1.0.0.tgz",
       "integrity": "sha512-XslfWrAGCYovQjveHODR0hllUrsn3UtvPFTkamHbgVHmkUA6eCIDmw3JDWVLJvuntTvYjwaPGamlyzK4/HAEOA==",
       "requires": {
-        "lodash": "^4.17.15"
+        "lodash": "4.17.15"
       }
     },
     "growl": {
@@ -2972,7 +3024,7 @@
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "dev": true,
       "requires": {
-        "function-bind": "^1.1.1"
+        "function-bind": "1.1.1"
       }
     },
     "has-ansi": {
@@ -2980,7 +3032,7 @@
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -3011,7 +3063,7 @@
       "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
       "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
       "requires": {
-        "has-symbol-support-x": "^1.4.1"
+        "has-symbol-support-x": "1.4.2"
       }
     },
     "has-value": {
@@ -3019,9 +3071,9 @@
       "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "requires": {
-        "get-value": "^2.0.6",
-        "has-values": "^1.0.0",
-        "isobject": "^3.0.0"
+        "get-value": "2.0.6",
+        "has-values": "1.0.0",
+        "isobject": "3.0.1"
       }
     },
     "has-values": {
@@ -3029,8 +3081,8 @@
       "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "requires": {
-        "is-number": "^3.0.0",
-        "kind-of": "^4.0.0"
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
       },
       "dependencies": {
         "kind-of": {
@@ -3038,7 +3090,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -3049,8 +3101,8 @@
       "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "2.0.4",
+        "safe-buffer": "5.2.0"
       }
     },
     "hash.js": {
@@ -3059,8 +3111,8 @@
       "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.3",
-        "minimalistic-assert": "^1.0.1"
+        "inherits": "2.0.4",
+        "minimalistic-assert": "1.0.1"
       }
     },
     "he": {
@@ -3075,9 +3127,9 @@
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
       "dev": true,
       "requires": {
-        "hash.js": "^1.0.3",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.1"
+        "hash.js": "1.1.7",
+        "minimalistic-assert": "1.0.1",
+        "minimalistic-crypto-utils": "1.0.1"
       }
     },
     "homedir-polyfill": {
@@ -3086,7 +3138,7 @@
       "integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
       "dev": true,
       "requires": {
-        "parse-passwd": "^1.0.0"
+        "parse-passwd": "1.0.0"
       }
     },
     "hosted-git-info": {
@@ -3105,7 +3157,7 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "requires": {
-        "safer-buffer": ">= 2.1.2 < 3"
+        "safer-buffer": "2.1.2"
       }
     },
     "ieee754": {
@@ -3131,8 +3183,8 @@
       "integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
       "dev": true,
       "requires": {
-        "pkg-dir": "^3.0.0",
-        "resolve-cwd": "^2.0.0"
+        "pkg-dir": "3.0.0",
+        "resolve-cwd": "2.0.0"
       }
     },
     "imurmurhash": {
@@ -3152,8 +3204,8 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
       }
     },
     "inherits": {
@@ -3172,19 +3224,19 @@
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
       "integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
       "requires": {
-        "ansi-escapes": "^3.2.0",
-        "chalk": "^2.4.2",
-        "cli-cursor": "^2.1.0",
-        "cli-width": "^2.0.0",
-        "external-editor": "^3.0.3",
-        "figures": "^2.0.0",
-        "lodash": "^4.17.12",
+        "ansi-escapes": "3.2.0",
+        "chalk": "2.4.2",
+        "cli-cursor": "2.1.0",
+        "cli-width": "2.2.0",
+        "external-editor": "3.1.0",
+        "figures": "2.0.0",
+        "lodash": "4.17.15",
         "mute-stream": "0.0.7",
-        "run-async": "^2.2.0",
-        "rxjs": "^6.4.0",
-        "string-width": "^2.1.0",
-        "strip-ansi": "^5.1.0",
-        "through": "^2.3.6"
+        "run-async": "2.4.0",
+        "rxjs": "6.5.4",
+        "string-width": "2.1.1",
+        "strip-ansi": "5.2.0",
+        "through": "2.3.8"
       },
       "dependencies": {
         "ansi-regex": {
@@ -3197,7 +3249,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "requires": {
-            "ansi-regex": "^4.1.0"
+            "ansi-regex": "4.1.0"
           }
         }
       }
@@ -3218,8 +3270,8 @@
       "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
       "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
       "requires": {
-        "is-relative": "^1.0.0",
-        "is-windows": "^1.0.1"
+        "is-relative": "1.0.0",
+        "is-windows": "1.0.2"
       }
     },
     "is-accessor-descriptor": {
@@ -3227,7 +3279,7 @@
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "kind-of": {
@@ -3235,7 +3287,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -3251,7 +3303,7 @@
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
       "requires": {
-        "binary-extensions": "^1.0.0"
+        "binary-extensions": "1.13.1"
       }
     },
     "is-buffer": {
@@ -3270,7 +3322,7 @@
       "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "kind-of": {
@@ -3278,7 +3330,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -3294,9 +3346,9 @@
       "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
       "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
       "requires": {
-        "is-accessor-descriptor": "^0.1.6",
-        "is-data-descriptor": "^0.1.4",
-        "kind-of": "^5.0.0"
+        "is-accessor-descriptor": "0.1.6",
+        "is-data-descriptor": "0.1.4",
+        "kind-of": "5.1.0"
       },
       "dependencies": {
         "kind-of": {
@@ -3326,7 +3378,7 @@
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
       "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
       "requires": {
-        "is-extglob": "^2.1.0"
+        "is-extglob": "2.1.1"
       }
     },
     "is-negated-glob": {
@@ -3339,7 +3391,7 @@
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
       "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "kind-of": {
@@ -3347,7 +3399,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -3369,7 +3421,7 @@
       "integrity": "sha512-rNocXHgipO+rvnP6dk3zI20RpOtrAM/kzbB258Uw5BWr3TpXi861yzjo16Dn4hUox07iw5AyeMLHWsujkjzvRQ==",
       "dev": true,
       "requires": {
-        "is-path-inside": "^2.1.0"
+        "is-path-inside": "2.1.0"
       }
     },
     "is-path-inside": {
@@ -3378,7 +3430,7 @@
       "integrity": "sha512-wiyhTzfDWsvwAW53OBWF5zuvaOGlZ6PwYxAbPVDhpm+gM09xKQGjBq/8uYN12aDvMxnAnq3dxTyoSoRNmg5YFg==",
       "dev": true,
       "requires": {
-        "path-is-inside": "^1.0.2"
+        "path-is-inside": "1.0.2"
       }
     },
     "is-plain-obj": {
@@ -3391,7 +3443,7 @@
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "requires": {
-        "isobject": "^3.0.1"
+        "isobject": "3.0.1"
       }
     },
     "is-promise": {
@@ -3405,7 +3457,7 @@
       "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
       "dev": true,
       "requires": {
-        "has": "^1.0.3"
+        "has": "1.0.3"
       }
     },
     "is-relative": {
@@ -3413,7 +3465,7 @@
       "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
       "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
       "requires": {
-        "is-unc-path": "^1.0.0"
+        "is-unc-path": "1.0.0"
       }
     },
     "is-retry-allowed": {
@@ -3426,7 +3478,7 @@
       "resolved": "https://registry.npmjs.org/is-scoped/-/is-scoped-1.0.0.tgz",
       "integrity": "sha1-RJypgpnnEwOCViieyytUDcQ3yzA=",
       "requires": {
-        "scoped-regex": "^1.0.0"
+        "scoped-regex": "1.0.0"
       }
     },
     "is-stream": {
@@ -3440,7 +3492,7 @@
       "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
       "dev": true,
       "requires": {
-        "has-symbols": "^1.0.1"
+        "has-symbols": "1.0.1"
       }
     },
     "is-unc-path": {
@@ -3448,7 +3500,7 @@
       "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
       "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
       "requires": {
-        "unc-path-regex": "^0.1.2"
+        "unc-path-regex": "0.1.2"
       }
     },
     "is-utf8": {
@@ -3477,7 +3529,7 @@
       "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-3.0.3.tgz",
       "integrity": "sha512-8cJBL5tTd2OS0dM4jz07wQd5g0dCCqIhUxPIGtZfa5L6hWlvV5MHTITy/DBAsF+Oe2LS1X3krBUhNwaGUWpWxw==",
       "requires": {
-        "buffer-alloc": "^1.2.0"
+        "buffer-alloc": "1.2.0"
       }
     },
     "isexe": {
@@ -3495,9 +3547,9 @@
       "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.6.0.tgz",
       "integrity": "sha512-+XRlFseT8B3L9KyjxxLjfXSLMuErKDsd8DBNrsaxoViABMEZlOSCstwmw0qpoFX3+U6yWU1yhLudAe6/lETGGA==",
       "requires": {
-        "binaryextensions": "^2.1.2",
-        "editions": "^2.2.0",
-        "textextensions": "^2.5.0"
+        "binaryextensions": "2.2.0",
+        "editions": "2.3.0",
+        "textextensions": "2.6.0"
       }
     },
     "isurl": {
@@ -3505,8 +3557,8 @@
       "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
       "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
       "requires": {
-        "has-to-string-tag-x": "^1.2.0",
-        "is-object": "^1.0.1"
+        "has-to-string-tag-x": "1.4.1",
+        "is-object": "1.0.1"
       }
     },
     "js-yaml": {
@@ -3515,8 +3567,8 @@
       "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "dev": true,
       "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "1.0.10",
+        "esprima": "4.0.1"
       }
     },
     "json-parse-better-errors": {
@@ -3536,7 +3588,7 @@
       "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
       "dev": true,
       "requires": {
-        "minimist": "^1.2.0"
+        "minimist": "1.2.0"
       }
     },
     "jsonfile": {
@@ -3544,7 +3596,7 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "requires": {
-        "graceful-fs": "^4.1.6"
+        "graceful-fs": "4.2.3"
       }
     },
     "just-extend": {
@@ -3564,7 +3616,7 @@
       "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
       "dev": true,
       "requires": {
-        "invert-kv": "^2.0.0"
+        "invert-kv": "2.0.0"
       }
     },
     "load-json-file": {
@@ -3572,10 +3624,10 @@
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
       "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "parse-json": "^4.0.0",
-        "pify": "^3.0.0",
-        "strip-bom": "^3.0.0"
+        "graceful-fs": "4.2.3",
+        "parse-json": "4.0.0",
+        "pify": "3.0.0",
+        "strip-bom": "3.0.0"
       }
     },
     "loader-runner": {
@@ -3590,9 +3642,9 @@
       "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
       "dev": true,
       "requires": {
-        "big.js": "^5.2.2",
-        "emojis-list": "^3.0.0",
-        "json5": "^1.0.1"
+        "big.js": "5.2.2",
+        "emojis-list": "3.0.0",
+        "json5": "1.0.1"
       }
     },
     "locate-path": {
@@ -3600,8 +3652,8 @@
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
       "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
       "requires": {
-        "p-locate": "^3.0.0",
-        "path-exists": "^3.0.0"
+        "p-locate": "3.0.0",
+        "path-exists": "3.0.0"
       }
     },
     "lodash": {
@@ -3620,7 +3672,7 @@
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
       "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
       "requires": {
-        "chalk": "^2.0.1"
+        "chalk": "2.4.2"
       }
     },
     "lolex": {
@@ -3640,7 +3692,7 @@
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dev": true,
       "requires": {
-        "yallist": "^3.0.2"
+        "yallist": "3.1.1"
       }
     },
     "make-dir": {
@@ -3648,7 +3700,7 @@
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
       "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
       "requires": {
-        "pify": "^3.0.0"
+        "pify": "3.0.0"
       }
     },
     "make-error": {
@@ -3669,7 +3721,7 @@
       "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
       "dev": true,
       "requires": {
-        "p-defer": "^1.0.0"
+        "p-defer": "1.0.0"
       }
     },
     "map-cache": {
@@ -3682,7 +3734,7 @@
       "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "requires": {
-        "object-visit": "^1.0.0"
+        "object-visit": "1.0.1"
       }
     },
     "md5.js": {
@@ -3691,9 +3743,9 @@
       "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
       "dev": true,
       "requires": {
-        "hash-base": "^3.0.0",
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.1.2"
+        "hash-base": "3.0.4",
+        "inherits": "2.0.4",
+        "safe-buffer": "5.2.0"
       }
     },
     "mem": {
@@ -3702,9 +3754,9 @@
       "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
       "dev": true,
       "requires": {
-        "map-age-cleaner": "^0.1.1",
-        "mimic-fn": "^2.0.0",
-        "p-is-promise": "^2.0.0"
+        "map-age-cleaner": "0.1.3",
+        "mimic-fn": "2.1.0",
+        "p-is-promise": "2.1.0"
       },
       "dependencies": {
         "mimic-fn": {
@@ -3720,9 +3772,9 @@
       "resolved": "https://registry.npmjs.org/mem-fs/-/mem-fs-1.1.3.tgz",
       "integrity": "sha1-uK6NLj/Lb10/kWXBLUVRoGXZicw=",
       "requires": {
-        "through2": "^2.0.0",
-        "vinyl": "^1.1.0",
-        "vinyl-file": "^2.0.0"
+        "through2": "2.0.5",
+        "vinyl": "1.2.0",
+        "vinyl-file": "2.0.0"
       },
       "dependencies": {
         "clone": {
@@ -3745,8 +3797,8 @@
           "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
           "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
           "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
+            "readable-stream": "2.3.7",
+            "xtend": "4.0.2"
           }
         },
         "vinyl": {
@@ -3754,8 +3806,8 @@
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
           "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
           "requires": {
-            "clone": "^1.0.0",
-            "clone-stats": "^0.0.1",
+            "clone": "1.0.4",
+            "clone-stats": "0.0.1",
             "replace-ext": "0.0.1"
           }
         }
@@ -3766,17 +3818,17 @@
       "resolved": "https://registry.npmjs.org/mem-fs-editor/-/mem-fs-editor-5.1.0.tgz",
       "integrity": "sha512-2Yt2GCYEbcotYbIJagmow4gEtHDqzpq5XN94+yAx/NT5+bGqIjkXnm3KCUQfE6kRfScGp9IZknScoGRKu8L78w==",
       "requires": {
-        "commondir": "^1.0.1",
-        "deep-extend": "^0.6.0",
-        "ejs": "^2.5.9",
-        "glob": "^7.0.3",
-        "globby": "^8.0.1",
-        "isbinaryfile": "^3.0.2",
-        "mkdirp": "^0.5.0",
-        "multimatch": "^2.0.0",
-        "rimraf": "^2.2.8",
-        "through2": "^2.0.0",
-        "vinyl": "^2.0.1"
+        "commondir": "1.0.1",
+        "deep-extend": "0.6.0",
+        "ejs": "2.7.4",
+        "glob": "7.1.6",
+        "globby": "8.0.2",
+        "isbinaryfile": "3.0.3",
+        "mkdirp": "0.5.1",
+        "multimatch": "2.1.0",
+        "rimraf": "2.7.1",
+        "through2": "2.0.5",
+        "vinyl": "2.2.0"
       },
       "dependencies": {
         "rimraf": {
@@ -3784,7 +3836,7 @@
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
           "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
           "requires": {
-            "glob": "^7.1.3"
+            "glob": "7.1.6"
           }
         },
         "through2": {
@@ -3792,8 +3844,8 @@
           "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
           "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
           "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
+            "readable-stream": "2.3.7",
+            "xtend": "4.0.2"
           }
         }
       }
@@ -3804,8 +3856,8 @@
       "integrity": "sha512-jA0rdU5KoQMC0e6ppoNRtpp6vjFq6+NY7r8hywnC7V+1Xj/MtHwGIbB1QaK/dunyjWteJzmkpd7ooeWg10T7GA==",
       "dev": true,
       "requires": {
-        "errno": "^0.1.3",
-        "readable-stream": "^2.0.1"
+        "errno": "0.1.7",
+        "readable-stream": "2.3.7"
       }
     },
     "merge2": {
@@ -3818,19 +3870,19 @@
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
       "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
       "requires": {
-        "arr-diff": "^4.0.0",
-        "array-unique": "^0.3.2",
-        "braces": "^2.3.1",
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "extglob": "^2.0.4",
-        "fragment-cache": "^0.2.1",
-        "kind-of": "^6.0.2",
-        "nanomatch": "^1.2.9",
-        "object.pick": "^1.3.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.2"
+        "arr-diff": "4.0.0",
+        "array-unique": "0.3.2",
+        "braces": "2.3.2",
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "extglob": "2.0.4",
+        "fragment-cache": "0.2.1",
+        "kind-of": "6.0.3",
+        "nanomatch": "1.2.13",
+        "object.pick": "1.3.0",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
       }
     },
     "miller-rabin": {
@@ -3839,8 +3891,8 @@
       "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
       "dev": true,
       "requires": {
-        "bn.js": "^4.0.0",
-        "brorand": "^1.0.1"
+        "bn.js": "4.11.8",
+        "brorand": "1.1.0"
       }
     },
     "mimic-fn": {
@@ -3870,7 +3922,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "1.1.11"
       }
     },
     "minimist": {
@@ -3884,16 +3936,16 @@
       "integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
       "dev": true,
       "requires": {
-        "concat-stream": "^1.5.0",
-        "duplexify": "^3.4.2",
-        "end-of-stream": "^1.1.0",
-        "flush-write-stream": "^1.0.0",
-        "from2": "^2.1.0",
-        "parallel-transform": "^1.1.0",
-        "pump": "^3.0.0",
-        "pumpify": "^1.3.3",
-        "stream-each": "^1.1.0",
-        "through2": "^2.0.0"
+        "concat-stream": "1.6.2",
+        "duplexify": "3.7.1",
+        "end-of-stream": "1.4.4",
+        "flush-write-stream": "1.1.1",
+        "from2": "2.3.0",
+        "parallel-transform": "1.2.0",
+        "pump": "3.0.0",
+        "pumpify": "1.5.1",
+        "stream-each": "1.2.3",
+        "through2": "2.0.5"
       },
       "dependencies": {
         "through2": {
@@ -3902,8 +3954,8 @@
           "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
           "dev": true,
           "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
+            "readable-stream": "2.3.7",
+            "xtend": "4.0.2"
           }
         }
       }
@@ -3913,8 +3965,8 @@
       "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
       "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
       "requires": {
-        "for-in": "^1.0.2",
-        "is-extendable": "^1.0.1"
+        "for-in": "1.0.2",
+        "is-extendable": "1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -3922,7 +3974,7 @@
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "requires": {
-            "is-plain-object": "^2.0.4"
+            "is-plain-object": "2.0.4"
           }
         }
       }
@@ -3985,7 +4037,7 @@
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.1"
           }
         },
         "glob": {
@@ -3994,12 +4046,12 @@
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.4",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "ms": {
@@ -4014,7 +4066,7 @@
           "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -4025,12 +4077,12 @@
       "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
       "dev": true,
       "requires": {
-        "aproba": "^1.1.1",
-        "copy-concurrently": "^1.0.0",
-        "fs-write-stream-atomic": "^1.0.8",
-        "mkdirp": "^0.5.1",
-        "rimraf": "^2.5.4",
-        "run-queue": "^1.0.3"
+        "aproba": "1.2.0",
+        "copy-concurrently": "1.0.5",
+        "fs-write-stream-atomic": "1.0.10",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.7.1",
+        "run-queue": "1.0.3"
       },
       "dependencies": {
         "rimraf": {
@@ -4039,7 +4091,7 @@
           "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
           "dev": true,
           "requires": {
-            "glob": "^7.1.3"
+            "glob": "7.1.6"
           }
         }
       }
@@ -4054,10 +4106,10 @@
       "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
       "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
       "requires": {
-        "array-differ": "^1.0.0",
-        "array-union": "^1.0.1",
-        "arrify": "^1.0.0",
-        "minimatch": "^3.0.0"
+        "array-differ": "1.0.0",
+        "array-union": "1.0.2",
+        "arrify": "1.0.1",
+        "minimatch": "3.0.4"
       }
     },
     "mute-stream": {
@@ -4077,17 +4129,17 @@
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
       "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
       "requires": {
-        "arr-diff": "^4.0.0",
-        "array-unique": "^0.3.2",
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "fragment-cache": "^0.2.1",
-        "is-windows": "^1.0.2",
-        "kind-of": "^6.0.2",
-        "object.pick": "^1.3.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
+        "arr-diff": "4.0.0",
+        "array-unique": "0.3.2",
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "fragment-cache": "0.2.1",
+        "is-windows": "1.0.2",
+        "kind-of": "6.0.3",
+        "object.pick": "1.3.0",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
       }
     },
     "neo-async": {
@@ -4107,11 +4159,11 @@
       "integrity": "sha512-Ymbac/94xeIrMf59REBPOv0thr+CJVFMhrlAkW/gjCIE58BGQdCj0x7KRCb3yz+Ga2Rz3E9XXSvUyyxqqhjQAQ==",
       "dev": true,
       "requires": {
-        "@sinonjs/formatio": "^3.2.1",
-        "@sinonjs/text-encoding": "^0.7.1",
-        "just-extend": "^4.0.2",
-        "lolex": "^5.0.1",
-        "path-to-regexp": "^1.7.0"
+        "@sinonjs/formatio": "3.2.2",
+        "@sinonjs/text-encoding": "0.7.1",
+        "just-extend": "4.1.0",
+        "lolex": "5.1.2",
+        "path-to-regexp": "1.8.0"
       },
       "dependencies": {
         "@sinonjs/formatio": {
@@ -4120,8 +4172,8 @@
           "integrity": "sha512-B8SEsgd8gArBLMD6zpRw3juQ2FVSsmdd7qlevyDqzS9WTCtvF55/gAL+h6gue8ZvPYcdiPdvueM/qm//9XzyTQ==",
           "dev": true,
           "requires": {
-            "@sinonjs/commons": "^1",
-            "@sinonjs/samsam": "^3.1.0"
+            "@sinonjs/commons": "1.7.1",
+            "@sinonjs/samsam": "3.3.3"
           }
         },
         "lolex": {
@@ -4130,7 +4182,7 @@
           "integrity": "sha512-h4hmjAvHTmd+25JSwrtTIuwbKdwg5NzZVRMLn9saij4SZaepCrTCxPr35H/3bjwfMJtN+t3CX8672UIkglz28A==",
           "dev": true,
           "requires": {
-            "@sinonjs/commons": "^1.7.0"
+            "@sinonjs/commons": "1.7.1"
           }
         }
       }
@@ -4141,8 +4193,8 @@
       "integrity": "sha512-VNYPRfGfmZLx0Ye20jWzHUjyTW/c+6Wq+iLhDzUI4XmhrDd9l/FozXV3F2xOaXjvp0co0+v1YSR3CMP6g+VvLQ==",
       "dev": true,
       "requires": {
-        "object.getownpropertydescriptors": "^2.0.3",
-        "semver": "^5.7.0"
+        "object.getownpropertydescriptors": "2.1.0",
+        "semver": "5.7.1"
       },
       "dependencies": {
         "semver": {
@@ -4159,29 +4211,29 @@
       "integrity": "sha512-h/zcD8H9kaDZ9ALUWwlBUDo6TKF8a7qBSCSEGfjTVIYeqsioSKaAX+BN7NgiMGp6iSIXZ3PxgCu8KS3b71YK5Q==",
       "dev": true,
       "requires": {
-        "assert": "^1.1.1",
-        "browserify-zlib": "^0.2.0",
-        "buffer": "^4.3.0",
-        "console-browserify": "^1.1.0",
-        "constants-browserify": "^1.0.0",
-        "crypto-browserify": "^3.11.0",
-        "domain-browser": "^1.1.1",
-        "events": "^3.0.0",
-        "https-browserify": "^1.0.0",
-        "os-browserify": "^0.3.0",
+        "assert": "1.5.0",
+        "browserify-zlib": "0.2.0",
+        "buffer": "4.9.2",
+        "console-browserify": "1.2.0",
+        "constants-browserify": "1.0.0",
+        "crypto-browserify": "3.12.0",
+        "domain-browser": "1.2.0",
+        "events": "3.1.0",
+        "https-browserify": "1.0.0",
+        "os-browserify": "0.3.0",
         "path-browserify": "0.0.1",
-        "process": "^0.11.10",
-        "punycode": "^1.2.4",
-        "querystring-es3": "^0.2.0",
-        "readable-stream": "^2.3.3",
-        "stream-browserify": "^2.0.1",
-        "stream-http": "^2.7.2",
-        "string_decoder": "^1.0.0",
-        "timers-browserify": "^2.0.4",
+        "process": "0.11.10",
+        "punycode": "1.4.1",
+        "querystring-es3": "0.2.1",
+        "readable-stream": "2.3.7",
+        "stream-browserify": "2.0.2",
+        "stream-http": "2.8.3",
+        "string_decoder": "1.1.1",
+        "timers-browserify": "2.0.11",
         "tty-browserify": "0.0.0",
-        "url": "^0.11.0",
-        "util": "^0.11.0",
-        "vm-browserify": "^1.0.1"
+        "url": "0.11.0",
+        "util": "0.11.1",
+        "vm-browserify": "1.1.2"
       },
       "dependencies": {
         "punycode": {
@@ -4197,10 +4249,10 @@
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
       "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
       "requires": {
-        "hosted-git-info": "^2.1.4",
-        "resolve": "^1.10.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
+        "hosted-git-info": "2.8.8",
+        "resolve": "1.15.1",
+        "semver": "5.7.1",
+        "validate-npm-package-license": "3.0.4"
       },
       "dependencies": {
         "semver": {
@@ -4222,7 +4274,7 @@
       "integrity": "sha512-IFsj0R9C7ZdR5cP+ET342q77uSRdtWOlWpih5eC+lu29tIDbNEgDbzgVJ5UFvYHWhxDZ5TFkJafFioO0pPQjCw==",
       "dev": true,
       "requires": {
-        "which": "^1.2.10"
+        "which": "1.3.1"
       }
     },
     "npm-run": {
@@ -4231,10 +4283,10 @@
       "integrity": "sha512-s7FyRpHUgaJfzkRgOnevX8rAWWsv1dofY1XS7hliWCF6LSQh+HtDfBvpigPS1krLvXw+Fi17CYMY8mUtblnyWw==",
       "dev": true,
       "requires": {
-        "minimist": "^1.2.0",
-        "npm-path": "^2.0.4",
-        "npm-which": "^3.0.1",
-        "serializerr": "^1.0.3"
+        "minimist": "1.2.0",
+        "npm-path": "2.0.4",
+        "npm-which": "3.0.1",
+        "serializerr": "1.0.3"
       }
     },
     "npm-run-path": {
@@ -4243,7 +4295,7 @@
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "dev": true,
       "requires": {
-        "path-key": "^2.0.0"
+        "path-key": "2.0.1"
       }
     },
     "npm-which": {
@@ -4252,9 +4304,9 @@
       "integrity": "sha1-kiXybsOihcIJyuZ8OxGmtKtxQKo=",
       "dev": true,
       "requires": {
-        "commander": "^2.9.0",
-        "npm-path": "^2.0.2",
-        "which": "^1.2.10"
+        "commander": "2.20.3",
+        "npm-path": "2.0.4",
+        "which": "1.3.1"
       }
     },
     "number-is-nan": {
@@ -4273,9 +4325,9 @@
       "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "requires": {
-        "copy-descriptor": "^0.1.0",
-        "define-property": "^0.2.5",
-        "kind-of": "^3.0.3"
+        "copy-descriptor": "0.1.1",
+        "define-property": "0.2.5",
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "define-property": {
@@ -4283,7 +4335,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "kind-of": {
@@ -4291,7 +4343,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -4313,7 +4365,7 @@
       "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "requires": {
-        "isobject": "^3.0.0"
+        "isobject": "3.0.1"
       }
     },
     "object.assign": {
@@ -4322,10 +4374,10 @@
       "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "function-bind": "^1.1.1",
-        "has-symbols": "^1.0.0",
-        "object-keys": "^1.0.11"
+        "define-properties": "1.1.3",
+        "function-bind": "1.1.1",
+        "has-symbols": "1.0.1",
+        "object-keys": "1.1.1"
       }
     },
     "object.getownpropertydescriptors": {
@@ -4334,8 +4386,8 @@
       "integrity": "sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.0-next.1"
+        "define-properties": "1.1.3",
+        "es-abstract": "1.17.4"
       }
     },
     "object.pick": {
@@ -4343,7 +4395,7 @@
       "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "requires": {
-        "isobject": "^3.0.1"
+        "isobject": "3.0.1"
       }
     },
     "once": {
@@ -4351,7 +4403,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1"
+        "wrappy": "1.0.2"
       }
     },
     "onetime": {
@@ -4359,7 +4411,7 @@
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "requires": {
-        "mimic-fn": "^1.0.0"
+        "mimic-fn": "1.2.0"
       }
     },
     "os-browserify": {
@@ -4374,9 +4426,9 @@
       "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
       "dev": true,
       "requires": {
-        "execa": "^1.0.0",
-        "lcid": "^2.0.0",
-        "mem": "^4.0.0"
+        "execa": "1.0.0",
+        "lcid": "2.0.0",
+        "mem": "4.3.0"
       }
     },
     "os-tmpdir": {
@@ -4411,7 +4463,7 @@
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
       "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
       "requires": {
-        "p-try": "^2.0.0"
+        "p-try": "2.2.0"
       }
     },
     "p-locate": {
@@ -4419,7 +4471,7 @@
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
       "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
       "requires": {
-        "p-limit": "^2.0.0"
+        "p-limit": "2.2.2"
       }
     },
     "p-map": {
@@ -4433,7 +4485,7 @@
       "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
       "integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
       "requires": {
-        "p-finally": "^1.0.0"
+        "p-finally": "1.0.0"
       }
     },
     "p-try": {
@@ -4458,9 +4510,9 @@
       "integrity": "sha512-P2vSmIu38uIlvdcU7fDkyrxj33gTUy/ABO5ZUbGowxNCopBq/OoD42bP4UmMrJoPyk4Uqf0mu3mtWBhHCZD8yg==",
       "dev": true,
       "requires": {
-        "cyclist": "^1.0.1",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.1.5"
+        "cyclist": "1.0.1",
+        "inherits": "2.0.4",
+        "readable-stream": "2.3.7"
       }
     },
     "parse-asn1": {
@@ -4469,12 +4521,12 @@
       "integrity": "sha512-jkMYn1dcJqF6d5CpU689bq7w/b5ALS9ROVSpQDPrZsqqesUJii9qutvoT5ltGedNXMO2e16YUWIghG9KxaViTQ==",
       "dev": true,
       "requires": {
-        "asn1.js": "^4.0.0",
-        "browserify-aes": "^1.0.0",
-        "create-hash": "^1.1.0",
-        "evp_bytestokey": "^1.0.0",
-        "pbkdf2": "^3.0.3",
-        "safe-buffer": "^5.1.1"
+        "asn1.js": "4.10.1",
+        "browserify-aes": "1.2.0",
+        "create-hash": "1.2.0",
+        "evp_bytestokey": "1.0.3",
+        "pbkdf2": "3.0.17",
+        "safe-buffer": "5.2.0"
       }
     },
     "parse-json": {
@@ -4482,8 +4534,8 @@
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
       "requires": {
-        "error-ex": "^1.3.1",
-        "json-parse-better-errors": "^1.0.1"
+        "error-ex": "1.3.2",
+        "json-parse-better-errors": "1.0.2"
       }
     },
     "parse-passwd": {
@@ -4556,7 +4608,7 @@
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
       "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
       "requires": {
-        "pify": "^3.0.0"
+        "pify": "3.0.0"
       }
     },
     "pathval": {
@@ -4571,11 +4623,11 @@
       "integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
       "dev": true,
       "requires": {
-        "create-hash": "^1.1.2",
-        "create-hmac": "^1.1.4",
-        "ripemd160": "^2.0.1",
-        "safe-buffer": "^5.0.1",
-        "sha.js": "^2.4.8"
+        "create-hash": "1.2.0",
+        "create-hmac": "1.1.7",
+        "ripemd160": "2.0.2",
+        "safe-buffer": "5.2.0",
+        "sha.js": "2.4.11"
       }
     },
     "picomatch": {
@@ -4599,7 +4651,7 @@
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "requires": {
-        "pinkie": "^2.0.0"
+        "pinkie": "2.0.4"
       }
     },
     "pkg-dir": {
@@ -4608,7 +4660,7 @@
       "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
       "dev": true,
       "requires": {
-        "find-up": "^3.0.0"
+        "find-up": "3.0.0"
       }
     },
     "posix-character-classes": {
@@ -4661,12 +4713,12 @@
       "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
       "dev": true,
       "requires": {
-        "bn.js": "^4.1.0",
-        "browserify-rsa": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "parse-asn1": "^5.0.0",
-        "randombytes": "^2.0.1",
-        "safe-buffer": "^5.1.2"
+        "bn.js": "4.11.8",
+        "browserify-rsa": "4.0.1",
+        "create-hash": "1.2.0",
+        "parse-asn1": "5.1.5",
+        "randombytes": "2.1.0",
+        "safe-buffer": "5.2.0"
       }
     },
     "pump": {
@@ -4675,8 +4727,8 @@
       "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
       "dev": true,
       "requires": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
+        "end-of-stream": "1.4.4",
+        "once": "1.4.0"
       }
     },
     "pumpify": {
@@ -4685,9 +4737,9 @@
       "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
       "dev": true,
       "requires": {
-        "duplexify": "^3.6.0",
-        "inherits": "^2.0.3",
-        "pump": "^2.0.0"
+        "duplexify": "3.7.1",
+        "inherits": "2.0.4",
+        "pump": "2.0.1"
       },
       "dependencies": {
         "pump": {
@@ -4696,8 +4748,8 @@
           "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
           "dev": true,
           "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
+            "end-of-stream": "1.4.4",
+            "once": "1.4.0"
           }
         }
       }
@@ -4726,7 +4778,7 @@
       "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
       "dev": true,
       "requires": {
-        "safe-buffer": "^5.1.0"
+        "safe-buffer": "5.2.0"
       }
     },
     "randomfill": {
@@ -4735,8 +4787,8 @@
       "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
       "dev": true,
       "requires": {
-        "randombytes": "^2.0.5",
-        "safe-buffer": "^5.1.0"
+        "randombytes": "2.1.0",
+        "safe-buffer": "5.2.0"
       }
     },
     "read-chunk": {
@@ -4744,8 +4796,8 @@
       "resolved": "https://registry.npmjs.org/read-chunk/-/read-chunk-3.2.0.tgz",
       "integrity": "sha512-CEjy9LCzhmD7nUpJ1oVOE6s/hBkejlcJEgLQHVnQznOSilOPb+kpKktlLfFDK3/WP43+F80xkUTM2VOkYoSYvQ==",
       "requires": {
-        "pify": "^4.0.1",
-        "with-open-file": "^0.1.6"
+        "pify": "4.0.1",
+        "with-open-file": "0.1.7"
       },
       "dependencies": {
         "pify": {
@@ -4760,9 +4812,9 @@
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
       "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
       "requires": {
-        "load-json-file": "^4.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^3.0.0"
+        "load-json-file": "4.0.0",
+        "normalize-package-data": "2.5.0",
+        "path-type": "3.0.0"
       }
     },
     "read-pkg-up": {
@@ -4770,8 +4822,8 @@
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
       "integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
       "requires": {
-        "find-up": "^3.0.0",
-        "read-pkg": "^3.0.0"
+        "find-up": "3.0.0",
+        "read-pkg": "3.0.0"
       }
     },
     "readable-stream": {
@@ -4779,13 +4831,13 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
       "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
       "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.4",
+        "isarray": "1.0.0",
+        "process-nextick-args": "2.0.1",
+        "safe-buffer": "5.1.2",
+        "string_decoder": "1.1.1",
+        "util-deprecate": "1.0.2"
       },
       "dependencies": {
         "safe-buffer": {
@@ -4801,9 +4853,9 @@
       "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.11",
-        "micromatch": "^3.1.10",
-        "readable-stream": "^2.0.2"
+        "graceful-fs": "4.2.3",
+        "micromatch": "3.1.10",
+        "readable-stream": "2.3.7"
       }
     },
     "rechoir": {
@@ -4811,7 +4863,7 @@
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "requires": {
-        "resolve": "^1.1.6"
+        "resolve": "1.15.1"
       }
     },
     "regex-not": {
@@ -4819,8 +4871,8 @@
       "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
       "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
       "requires": {
-        "extend-shallow": "^3.0.2",
-        "safe-regex": "^1.1.0"
+        "extend-shallow": "3.0.2",
+        "safe-regex": "1.1.0"
       }
     },
     "remove-trailing-separator": {
@@ -4860,7 +4912,7 @@
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
       "integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
       "requires": {
-        "path-parse": "^1.0.6"
+        "path-parse": "1.0.6"
       }
     },
     "resolve-cwd": {
@@ -4869,7 +4921,7 @@
       "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
       "dev": true,
       "requires": {
-        "resolve-from": "^3.0.0"
+        "resolve-from": "3.0.0"
       }
     },
     "resolve-dir": {
@@ -4878,8 +4930,8 @@
       "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
       "dev": true,
       "requires": {
-        "expand-tilde": "^2.0.0",
-        "global-modules": "^1.0.0"
+        "expand-tilde": "2.0.2",
+        "global-modules": "1.0.0"
       },
       "dependencies": {
         "global-modules": {
@@ -4888,9 +4940,9 @@
           "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
           "dev": true,
           "requires": {
-            "global-prefix": "^1.0.1",
-            "is-windows": "^1.0.1",
-            "resolve-dir": "^1.0.0"
+            "global-prefix": "1.0.2",
+            "is-windows": "1.0.2",
+            "resolve-dir": "1.0.1"
           }
         }
       }
@@ -4911,8 +4963,8 @@
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "requires": {
-        "onetime": "^2.0.0",
-        "signal-exit": "^3.0.2"
+        "onetime": "2.0.1",
+        "signal-exit": "3.0.2"
       }
     },
     "ret": {
@@ -4926,7 +4978,7 @@
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
       "dev": true,
       "requires": {
-        "glob": "^7.1.3"
+        "glob": "7.1.6"
       }
     },
     "ripemd160": {
@@ -4935,8 +4987,8 @@
       "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
       "dev": true,
       "requires": {
-        "hash-base": "^3.0.0",
-        "inherits": "^2.0.1"
+        "hash-base": "3.0.4",
+        "inherits": "2.0.4"
       }
     },
     "run-async": {
@@ -4944,7 +4996,7 @@
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.0.tgz",
       "integrity": "sha512-xJTbh/d7Lm7SBhc1tNvTpeCHaEzoyxPrqNlvSdMfBTYwaY++UJFyXUOxAtsRUXjlqOfj8luNaR9vjCh4KeV+pg==",
       "requires": {
-        "is-promise": "^2.1.0"
+        "is-promise": "2.1.0"
       }
     },
     "run-queue": {
@@ -4953,7 +5005,7 @@
       "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
       "dev": true,
       "requires": {
-        "aproba": "^1.1.1"
+        "aproba": "1.2.0"
       }
     },
     "rxjs": {
@@ -4961,7 +5013,7 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.4.tgz",
       "integrity": "sha512-naMQXcgEo3csAEGvw/NydRA0fuS2nDZJiw1YUWFKU7aPPAPGZEsD4Iimit96qwCieH6y614MCLYwdkrWx7z/7Q==",
       "requires": {
-        "tslib": "^1.9.0"
+        "tslib": "1.11.1"
       }
     },
     "safe-buffer": {
@@ -4974,7 +5026,7 @@
       "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "requires": {
-        "ret": "~0.1.10"
+        "ret": "0.1.15"
       }
     },
     "safer-buffer": {
@@ -4994,9 +5046,9 @@
       "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
       "dev": true,
       "requires": {
-        "ajv": "^6.1.0",
-        "ajv-errors": "^1.0.0",
-        "ajv-keywords": "^3.1.0"
+        "ajv": "6.12.0",
+        "ajv-errors": "1.0.1",
+        "ajv-keywords": "3.4.1"
       }
     },
     "scoped-regex": {
@@ -5021,7 +5073,7 @@
       "integrity": "sha1-EtTFqhw/+49tHcXzlaqUVVacP5E=",
       "dev": true,
       "requires": {
-        "protochain": "^1.0.5"
+        "protochain": "1.0.5"
       }
     },
     "set-blocking": {
@@ -5035,10 +5087,10 @@
       "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
       "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
       "requires": {
-        "extend-shallow": "^2.0.1",
-        "is-extendable": "^0.1.1",
-        "is-plain-object": "^2.0.3",
-        "split-string": "^3.0.1"
+        "extend-shallow": "2.0.1",
+        "is-extendable": "0.1.1",
+        "is-plain-object": "2.0.4",
+        "split-string": "3.1.0"
       },
       "dependencies": {
         "extend-shallow": {
@@ -5046,7 +5098,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         }
       }
@@ -5063,8 +5115,8 @@
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "2.0.4",
+        "safe-buffer": "5.2.0"
       }
     },
     "shebang-command": {
@@ -5072,7 +5124,7 @@
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "requires": {
-        "shebang-regex": "^1.0.0"
+        "shebang-regex": "1.0.0"
       }
     },
     "shebang-regex": {
@@ -5085,9 +5137,9 @@
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.3.tgz",
       "integrity": "sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==",
       "requires": {
-        "glob": "^7.0.0",
-        "interpret": "^1.0.0",
-        "rechoir": "^0.6.2"
+        "glob": "7.1.6",
+        "interpret": "1.2.0",
+        "rechoir": "0.6.2"
       }
     },
     "shimmer": {
@@ -5106,13 +5158,13 @@
       "integrity": "sha512-h/3uHscbt5pQNxkf7Y/Lb9/OM44YNCicHakcq73ncbrIS8lXg+ZGOZbtuU+/km4YnyiCYfQQEwANaReJz7KDfw==",
       "dev": true,
       "requires": {
-        "@sinonjs/formatio": "^2.0.0",
-        "diff": "^3.5.0",
-        "lodash.get": "^4.4.2",
-        "lolex": "^2.4.2",
-        "nise": "^1.3.3",
-        "supports-color": "^5.4.0",
-        "type-detect": "^4.0.8"
+        "@sinonjs/formatio": "2.0.0",
+        "diff": "3.5.0",
+        "lodash.get": "4.4.2",
+        "lolex": "2.7.5",
+        "nise": "1.5.3",
+        "supports-color": "5.5.0",
+        "type-detect": "4.0.8"
       }
     },
     "slash": {
@@ -5125,14 +5177,14 @@
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
       "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
       "requires": {
-        "base": "^0.11.1",
-        "debug": "^2.2.0",
-        "define-property": "^0.2.5",
-        "extend-shallow": "^2.0.1",
-        "map-cache": "^0.2.2",
-        "source-map": "^0.5.6",
-        "source-map-resolve": "^0.5.0",
-        "use": "^3.1.0"
+        "base": "0.11.2",
+        "debug": "2.6.9",
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "map-cache": "0.2.2",
+        "source-map": "0.5.7",
+        "source-map-resolve": "0.5.3",
+        "use": "3.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -5140,7 +5192,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "extend-shallow": {
@@ -5148,7 +5200,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         }
       }
@@ -5158,9 +5210,9 @@
       "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
       "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
       "requires": {
-        "define-property": "^1.0.0",
-        "isobject": "^3.0.0",
-        "snapdragon-util": "^3.0.1"
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "snapdragon-util": "3.0.1"
       },
       "dependencies": {
         "define-property": {
@@ -5168,7 +5220,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "requires": {
-            "is-descriptor": "^1.0.0"
+            "is-descriptor": "1.0.2"
           }
         },
         "is-accessor-descriptor": {
@@ -5176,7 +5228,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.3"
           }
         },
         "is-data-descriptor": {
@@ -5184,7 +5236,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.3"
           }
         },
         "is-descriptor": {
@@ -5192,9 +5244,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.3"
           }
         }
       }
@@ -5204,7 +5256,7 @@
       "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
       "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
       "requires": {
-        "kind-of": "^3.2.0"
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "kind-of": {
@@ -5212,7 +5264,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -5233,11 +5285,11 @@
       "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
       "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
       "requires": {
-        "atob": "^2.1.2",
-        "decode-uri-component": "^0.2.0",
-        "resolve-url": "^0.2.1",
-        "source-map-url": "^0.4.0",
-        "urix": "^0.1.0"
+        "atob": "2.1.2",
+        "decode-uri-component": "0.2.0",
+        "resolve-url": "0.2.1",
+        "source-map-url": "0.4.0",
+        "urix": "0.1.0"
       }
     },
     "source-map-support": {
@@ -5246,8 +5298,8 @@
       "integrity": "sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==",
       "dev": true,
       "requires": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
+        "buffer-from": "1.1.1",
+        "source-map": "0.6.1"
       },
       "dependencies": {
         "source-map": {
@@ -5268,8 +5320,8 @@
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
       "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
       "requires": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
+        "spdx-expression-parse": "3.0.0",
+        "spdx-license-ids": "3.0.5"
       }
     },
     "spdx-exceptions": {
@@ -5282,8 +5334,8 @@
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
       "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
       "requires": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
+        "spdx-exceptions": "2.2.0",
+        "spdx-license-ids": "3.0.5"
       }
     },
     "spdx-license-ids": {
@@ -5296,7 +5348,7 @@
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
       "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
       "requires": {
-        "extend-shallow": "^3.0.0"
+        "extend-shallow": "3.0.2"
       }
     },
     "sprintf-js": {
@@ -5311,7 +5363,7 @@
       "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
       "dev": true,
       "requires": {
-        "figgy-pudding": "^3.5.1"
+        "figgy-pudding": "3.5.1"
       }
     },
     "stack-chain": {
@@ -5324,8 +5376,8 @@
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "requires": {
-        "define-property": "^0.2.5",
-        "object-copy": "^0.1.0"
+        "define-property": "0.2.5",
+        "object-copy": "0.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -5333,7 +5385,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         }
       }
@@ -5344,8 +5396,8 @@
       "integrity": "sha512-nX6hmklHs/gr2FuxYDltq8fJA1GDlxKQCz8O/IM4atRqBH8OORmBNgfvW5gG10GT/qQ9u0CzIvr2X5Pkt6ntqg==",
       "dev": true,
       "requires": {
-        "inherits": "~2.0.1",
-        "readable-stream": "^2.0.2"
+        "inherits": "2.0.4",
+        "readable-stream": "2.3.7"
       }
     },
     "stream-each": {
@@ -5354,8 +5406,8 @@
       "integrity": "sha512-vlMC2f8I2u/bZGqkdfLQW/13Zihpej/7PmSiMQsbYddxuTsJp8vRe2x2FvVExZg7FaOds43ROAuFJwPR4MTZLw==",
       "dev": true,
       "requires": {
-        "end-of-stream": "^1.1.0",
-        "stream-shift": "^1.0.0"
+        "end-of-stream": "1.4.4",
+        "stream-shift": "1.0.1"
       }
     },
     "stream-http": {
@@ -5364,11 +5416,11 @@
       "integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
       "dev": true,
       "requires": {
-        "builtin-status-codes": "^3.0.0",
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.3.6",
-        "to-arraybuffer": "^1.0.0",
-        "xtend": "^4.0.0"
+        "builtin-status-codes": "3.0.0",
+        "inherits": "2.0.4",
+        "readable-stream": "2.3.7",
+        "to-arraybuffer": "1.0.1",
+        "xtend": "4.0.2"
       }
     },
     "stream-shift": {
@@ -5387,8 +5439,8 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "requires": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
+        "is-fullwidth-code-point": "2.0.0",
+        "strip-ansi": "4.0.0"
       }
     },
     "string.prototype.trimleft": {
@@ -5397,8 +5449,8 @@
       "integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.3",
-        "function-bind": "^1.1.1"
+        "define-properties": "1.1.3",
+        "function-bind": "1.1.1"
       }
     },
     "string.prototype.trimright": {
@@ -5407,8 +5459,8 @@
       "integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.3",
-        "function-bind": "^1.1.1"
+        "define-properties": "1.1.3",
+        "function-bind": "1.1.1"
       }
     },
     "string_decoder": {
@@ -5416,7 +5468,7 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
-        "safe-buffer": "~5.1.0"
+        "safe-buffer": "5.1.2"
       },
       "dependencies": {
         "safe-buffer": {
@@ -5431,7 +5483,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
       "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
       "requires": {
-        "ansi-regex": "^3.0.0"
+        "ansi-regex": "3.0.0"
       }
     },
     "strip-bom": {
@@ -5444,8 +5496,8 @@
       "resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-2.0.0.tgz",
       "integrity": "sha1-+H217yYT9paKpUWr/h7HKLaoKco=",
       "requires": {
-        "first-chunk-stream": "^2.0.0",
-        "strip-bom": "^2.0.0"
+        "first-chunk-stream": "2.0.0",
+        "strip-bom": "2.0.0"
       },
       "dependencies": {
         "strip-bom": {
@@ -5453,7 +5505,7 @@
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "requires": {
-            "is-utf8": "^0.2.0"
+            "is-utf8": "0.2.1"
           }
         }
       }
@@ -5475,7 +5527,7 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "requires": {
-        "has-flag": "^3.0.0"
+        "has-flag": "3.0.0"
       }
     },
     "symbol-observable": {
@@ -5489,8 +5541,8 @@
       "resolved": "https://registry.npmjs.org/taketalk/-/taketalk-1.0.0.tgz",
       "integrity": "sha1-tNTw3u0gauffd1sSnqLKbeUvJt0=",
       "requires": {
-        "get-stdin": "^4.0.1",
-        "minimist": "^1.1.0"
+        "get-stdin": "4.0.1",
+        "minimist": "1.2.0"
       }
     },
     "tapable": {
@@ -5505,9 +5557,9 @@
       "integrity": "sha512-4lYPyeNmstjIIESr/ysHg2vUPRGf2tzF9z2yYwnowXVuVzLEamPN1Gfrz7f8I9uEPuHcbFlW4PLIAsJoxXyJ1g==",
       "dev": true,
       "requires": {
-        "commander": "^2.20.0",
-        "source-map": "~0.6.1",
-        "source-map-support": "~0.5.12"
+        "commander": "2.20.3",
+        "source-map": "0.6.1",
+        "source-map-support": "0.5.16"
       },
       "dependencies": {
         "source-map": {
@@ -5524,15 +5576,15 @@
       "integrity": "sha512-QMxecFz/gHQwteWwSo5nTc6UaICqN1bMedC5sMtUc7y3Ha3Q8y6ZO0iCR8pq4RJC8Hjf0FEPEHZqcMB/+DFCrA==",
       "dev": true,
       "requires": {
-        "cacache": "^12.0.2",
-        "find-cache-dir": "^2.1.0",
-        "is-wsl": "^1.1.0",
-        "schema-utils": "^1.0.0",
-        "serialize-javascript": "^2.1.2",
-        "source-map": "^0.6.1",
-        "terser": "^4.1.2",
-        "webpack-sources": "^1.4.0",
-        "worker-farm": "^1.7.0"
+        "cacache": "12.0.3",
+        "find-cache-dir": "2.1.0",
+        "is-wsl": "1.1.0",
+        "schema-utils": "1.0.0",
+        "serialize-javascript": "2.1.2",
+        "source-map": "0.6.1",
+        "terser": "4.6.6",
+        "webpack-sources": "1.4.3",
+        "worker-farm": "1.7.0"
       },
       "dependencies": {
         "source-map": {
@@ -5563,7 +5615,7 @@
       "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
       "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
       "requires": {
-        "readable-stream": "2 || 3"
+        "readable-stream": "2.3.7"
       }
     },
     "timed-out": {
@@ -5577,7 +5629,7 @@
       "integrity": "sha512-60aV6sgJ5YEbzUdn9c8kYGIqOubPoUdqQCul3SBAsRCZ40s6Y5cMcrW4dt3/k/EsbLVJNl9n6Vz3fTc+k2GeKQ==",
       "dev": true,
       "requires": {
-        "setimmediate": "^1.0.4"
+        "setimmediate": "1.0.5"
       }
     },
     "tmp": {
@@ -5585,7 +5637,7 @@
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "requires": {
-        "os-tmpdir": "~1.0.2"
+        "os-tmpdir": "1.0.2"
       }
     },
     "to-arraybuffer": {
@@ -5599,7 +5651,7 @@
       "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "kind-of": {
@@ -5607,7 +5659,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -5617,10 +5669,10 @@
       "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
       "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
       "requires": {
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "regex-not": "^1.0.2",
-        "safe-regex": "^1.1.0"
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "regex-not": "1.0.2",
+        "safe-regex": "1.1.0"
       }
     },
     "to-regex-range": {
@@ -5628,8 +5680,8 @@
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "requires": {
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1"
+        "is-number": "3.0.0",
+        "repeat-string": "1.6.1"
       }
     },
     "ts-loader": {
@@ -5638,11 +5690,11 @@
       "integrity": "sha512-Dd9FekWuABGgjE1g0TlQJ+4dFUfYGbYcs52/HQObE0ZmUNjQlmLAS7xXsSzy23AMaMwipsx5sNHvoEpT2CZq1g==",
       "dev": true,
       "requires": {
-        "chalk": "^2.3.0",
-        "enhanced-resolve": "^4.0.0",
-        "loader-utils": "^1.0.2",
-        "micromatch": "^4.0.0",
-        "semver": "^6.0.0"
+        "chalk": "2.4.2",
+        "enhanced-resolve": "4.1.1",
+        "loader-utils": "1.4.0",
+        "micromatch": "4.0.2",
+        "semver": "6.3.0"
       },
       "dependencies": {
         "braces": {
@@ -5651,7 +5703,7 @@
           "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
           "dev": true,
           "requires": {
-            "fill-range": "^7.0.1"
+            "fill-range": "7.0.1"
           }
         },
         "fill-range": {
@@ -5660,7 +5712,7 @@
           "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
           "dev": true,
           "requires": {
-            "to-regex-range": "^5.0.1"
+            "to-regex-range": "5.0.1"
           }
         },
         "is-number": {
@@ -5675,8 +5727,8 @@
           "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
           "dev": true,
           "requires": {
-            "braces": "^3.0.1",
-            "picomatch": "^2.0.5"
+            "braces": "3.0.2",
+            "picomatch": "2.2.1"
           }
         },
         "to-regex-range": {
@@ -5685,7 +5737,7 @@
           "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
           "dev": true,
           "requires": {
-            "is-number": "^7.0.0"
+            "is-number": "7.0.0"
           }
         }
       }
@@ -5695,14 +5747,14 @@
       "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-2.3.0.tgz",
       "integrity": "sha512-odfmlA1J045teLJ5W25U9Hfg662O7mswDkBWqIhxMaAyslUFftLEn3SIiaCgB1jsQzYApYhMTXkjLXxS3/jdeg==",
       "requires": {
-        "@dsherret/to-absolute-glob": "^2.0.2",
+        "@dsherret/to-absolute-glob": "2.0.2",
         "code-block-writer": "8.0.0",
-        "fs-extra": "^7.0.0",
-        "glob-parent": "^3.1.0",
-        "globby": "^8.0.1",
-        "is-negated-glob": "^1.0.0",
-        "multimatch": "^2.1.0",
-        "typescript": "^3.0.1"
+        "fs-extra": "7.0.1",
+        "glob-parent": "3.1.0",
+        "globby": "8.0.2",
+        "is-negated-glob": "1.0.0",
+        "multimatch": "2.1.0",
+        "typescript": "3.8.3"
       }
     },
     "ts-node": {
@@ -5711,10 +5763,10 @@
       "integrity": "sha512-4mZEbofxGqLL2RImpe3zMJukvEvcO1XP8bj8ozBPySdCUXEcU5cIRwR0aM3R+VoZq7iXc8N86NC0FspGRqP4gg==",
       "dev": true,
       "requires": {
-        "arg": "^4.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "source-map-support": "^0.5.6",
+        "arg": "4.1.3",
+        "diff": "4.0.2",
+        "make-error": "1.3.6",
+        "source-map-support": "0.5.16",
         "yn": "3.1.1"
       },
       "dependencies": {
@@ -5764,10 +5816,10 @@
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
       "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
       "requires": {
-        "arr-union": "^3.1.0",
-        "get-value": "^2.0.6",
-        "is-extendable": "^0.1.1",
-        "set-value": "^2.0.1"
+        "arr-union": "3.1.0",
+        "get-value": "2.0.6",
+        "is-extendable": "0.1.1",
+        "set-value": "2.0.1"
       }
     },
     "unique-filename": {
@@ -5776,7 +5828,7 @@
       "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
       "dev": true,
       "requires": {
-        "unique-slug": "^2.0.0"
+        "unique-slug": "2.0.2"
       }
     },
     "unique-slug": {
@@ -5785,7 +5837,7 @@
       "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
       "dev": true,
       "requires": {
-        "imurmurhash": "^0.1.4"
+        "imurmurhash": "0.1.4"
       }
     },
     "universalify": {
@@ -5798,8 +5850,8 @@
       "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "requires": {
-        "has-value": "^0.3.1",
-        "isobject": "^3.0.0"
+        "has-value": "0.3.1",
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "has-value": {
@@ -5807,9 +5859,9 @@
           "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "requires": {
-            "get-value": "^2.0.3",
-            "has-values": "^0.1.4",
-            "isobject": "^2.0.0"
+            "get-value": "2.0.6",
+            "has-values": "0.1.4",
+            "isobject": "2.1.0"
           },
           "dependencies": {
             "isobject": {
@@ -5846,7 +5898,7 @@
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
       "dev": true,
       "requires": {
-        "punycode": "^2.1.0"
+        "punycode": "2.1.1"
       }
     },
     "urix": {
@@ -5877,7 +5929,7 @@
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
       "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
       "requires": {
-        "prepend-http": "^1.0.1"
+        "prepend-http": "1.0.4"
       }
     },
     "url-to-options": {
@@ -5933,8 +5985,8 @@
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
       "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
       "requires": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
+        "spdx-correct": "3.1.0",
+        "spdx-expression-parse": "3.0.0"
       }
     },
     "vinyl": {
@@ -5942,12 +5994,12 @@
       "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
       "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
       "requires": {
-        "clone": "^2.1.1",
-        "clone-buffer": "^1.0.0",
-        "clone-stats": "^1.0.0",
-        "cloneable-readable": "^1.0.0",
-        "remove-trailing-separator": "^1.0.1",
-        "replace-ext": "^1.0.0"
+        "clone": "2.1.2",
+        "clone-buffer": "1.0.0",
+        "clone-stats": "1.0.0",
+        "cloneable-readable": "1.1.3",
+        "remove-trailing-separator": "1.1.0",
+        "replace-ext": "1.0.0"
       }
     },
     "vinyl-file": {
@@ -5955,12 +6007,12 @@
       "resolved": "https://registry.npmjs.org/vinyl-file/-/vinyl-file-2.0.0.tgz",
       "integrity": "sha1-p+v1/779obfRjRQPyweyI++2dRo=",
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "pify": "^2.3.0",
-        "pinkie-promise": "^2.0.0",
-        "strip-bom": "^2.0.0",
-        "strip-bom-stream": "^2.0.0",
-        "vinyl": "^1.1.0"
+        "graceful-fs": "4.2.3",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "strip-bom": "2.0.0",
+        "strip-bom-stream": "2.0.0",
+        "vinyl": "1.2.0"
       },
       "dependencies": {
         "clone": {
@@ -5988,7 +6040,7 @@
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "requires": {
-            "is-utf8": "^0.2.0"
+            "is-utf8": "0.2.1"
           }
         },
         "vinyl": {
@@ -5996,8 +6048,8 @@
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
           "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
           "requires": {
-            "clone": "^1.0.0",
-            "clone-stats": "^0.0.1",
+            "clone": "1.0.4",
+            "clone-stats": "0.0.1",
             "replace-ext": "0.0.1"
           }
         }
@@ -6015,9 +6067,9 @@
       "integrity": "sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==",
       "dev": true,
       "requires": {
-        "chokidar": "^2.0.2",
-        "graceful-fs": "^4.1.2",
-        "neo-async": "^2.5.0"
+        "chokidar": "2.1.8",
+        "graceful-fs": "4.2.3",
+        "neo-async": "2.6.1"
       }
     },
     "webpack": {
@@ -6030,25 +6082,25 @@
         "@webassemblyjs/helper-module-context": "1.8.5",
         "@webassemblyjs/wasm-edit": "1.8.5",
         "@webassemblyjs/wasm-parser": "1.8.5",
-        "acorn": "^6.2.1",
-        "ajv": "^6.10.2",
-        "ajv-keywords": "^3.4.1",
-        "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^4.1.0",
-        "eslint-scope": "^4.0.3",
-        "json-parse-better-errors": "^1.0.2",
-        "loader-runner": "^2.4.0",
-        "loader-utils": "^1.2.3",
-        "memory-fs": "^0.4.1",
-        "micromatch": "^3.1.10",
-        "mkdirp": "^0.5.1",
-        "neo-async": "^2.6.1",
-        "node-libs-browser": "^2.2.1",
-        "schema-utils": "^1.0.0",
-        "tapable": "^1.1.3",
-        "terser-webpack-plugin": "^1.4.3",
-        "watchpack": "^1.6.0",
-        "webpack-sources": "^1.4.1"
+        "acorn": "6.4.0",
+        "ajv": "6.12.0",
+        "ajv-keywords": "3.4.1",
+        "chrome-trace-event": "1.0.2",
+        "enhanced-resolve": "4.1.1",
+        "eslint-scope": "4.0.3",
+        "json-parse-better-errors": "1.0.2",
+        "loader-runner": "2.4.0",
+        "loader-utils": "1.4.0",
+        "memory-fs": "0.4.1",
+        "micromatch": "3.1.10",
+        "mkdirp": "0.5.1",
+        "neo-async": "2.6.1",
+        "node-libs-browser": "2.2.1",
+        "schema-utils": "1.0.0",
+        "tapable": "1.1.3",
+        "terser-webpack-plugin": "1.4.3",
+        "watchpack": "1.6.0",
+        "webpack-sources": "1.4.3"
       },
       "dependencies": {
         "memory-fs": {
@@ -6057,8 +6109,8 @@
           "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
           "dev": true,
           "requires": {
-            "errno": "^0.1.3",
-            "readable-stream": "^2.0.1"
+            "errno": "0.1.7",
+            "readable-stream": "2.3.7"
           }
         }
       }
@@ -6100,9 +6152,9 @@
           "integrity": "sha512-F/7vkyTtyc/llOIn8oWclcB25KdRaiPBpZYDgJHgh/UHtpgT2p2eldQgtQnLtUvfMKPKxbRaQM/hHkvLHt1Vng==",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "memory-fs": "^0.4.0",
-            "tapable": "^1.0.0"
+            "graceful-fs": "4.2.3",
+            "memory-fs": "0.4.1",
+            "tapable": "1.1.3"
           }
         },
         "loader-utils": {
@@ -6111,9 +6163,9 @@
           "integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
           "dev": true,
           "requires": {
-            "big.js": "^5.2.2",
-            "emojis-list": "^2.0.0",
-            "json5": "^1.0.1"
+            "big.js": "5.2.2",
+            "emojis-list": "2.1.0",
+            "json5": "1.0.1"
           }
         },
         "memory-fs": {
@@ -6122,8 +6174,8 @@
           "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
           "dev": true,
           "requires": {
-            "errno": "^0.1.3",
-            "readable-stream": "^2.0.1"
+            "errno": "0.1.7",
+            "readable-stream": "2.3.7"
           }
         },
         "string-width": {
@@ -6132,9 +6184,9 @@
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
+            "emoji-regex": "7.0.3",
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "5.2.0"
           }
         },
         "strip-ansi": {
@@ -6143,7 +6195,7 @@
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^4.1.0"
+            "ansi-regex": "4.1.0"
           }
         },
         "supports-color": {
@@ -6152,7 +6204,7 @@
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         },
         "yargs": {
@@ -6161,17 +6213,17 @@
           "integrity": "sha512-HG/DWAJa1PAnHT9JAhNa8AbAv3FPaiLzioSjCcmuXXhP8MlpHO5vwls4g4j6n30Z74GVQj8Xa62dWVx1QCGklg==",
           "dev": true,
           "requires": {
-            "cliui": "^5.0.0",
-            "find-up": "^3.0.0",
-            "get-caller-file": "^2.0.1",
-            "os-locale": "^3.1.0",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^2.0.0",
-            "set-blocking": "^2.0.0",
-            "string-width": "^3.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^4.0.0",
-            "yargs-parser": "^13.1.0"
+            "cliui": "5.0.0",
+            "find-up": "3.0.0",
+            "get-caller-file": "2.0.5",
+            "os-locale": "3.1.0",
+            "require-directory": "2.1.1",
+            "require-main-filename": "2.0.0",
+            "set-blocking": "2.0.0",
+            "string-width": "3.1.0",
+            "which-module": "2.0.0",
+            "y18n": "4.0.0",
+            "yargs-parser": "13.1.1"
           }
         }
       }
@@ -6182,8 +6234,8 @@
       "integrity": "sha512-cX8G2vR/85UYG59FgkoMamwHUIkSSlV3bBMRsbxVXVUk2j6NleCKjQ/WE9eYg9WY4w25O9w8wKP4rzNZFmUcUg==",
       "dev": true,
       "requires": {
-        "ansi-colors": "^3.0.0",
-        "uuid": "^3.3.2"
+        "ansi-colors": "3.2.4",
+        "uuid": "3.4.0"
       }
     },
     "webpack-sources": {
@@ -6192,8 +6244,8 @@
       "integrity": "sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==",
       "dev": true,
       "requires": {
-        "source-list-map": "^2.0.0",
-        "source-map": "~0.6.1"
+        "source-list-map": "2.0.1",
+        "source-map": "0.6.1"
       },
       "dependencies": {
         "source-map": {
@@ -6209,7 +6261,7 @@
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "requires": {
-        "isexe": "^2.0.0"
+        "isexe": "2.0.0"
       }
     },
     "which-module": {
@@ -6224,7 +6276,7 @@
       "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
       "dev": true,
       "requires": {
-        "string-width": "^1.0.2 || 2"
+        "string-width": "2.1.1"
       }
     },
     "with-open-file": {
@@ -6232,9 +6284,9 @@
       "resolved": "https://registry.npmjs.org/with-open-file/-/with-open-file-0.1.7.tgz",
       "integrity": "sha512-ecJS2/oHtESJ1t3ZfMI3B7KIDKyfN0O16miWxdn30zdh66Yd3LsRFebXZXq6GU4xfxLf6nVxp9kIqElb5fqczA==",
       "requires": {
-        "p-finally": "^1.0.0",
-        "p-try": "^2.1.0",
-        "pify": "^4.0.1"
+        "p-finally": "1.0.0",
+        "p-try": "2.2.0",
+        "pify": "4.0.1"
       },
       "dependencies": {
         "pify": {
@@ -6250,7 +6302,7 @@
       "integrity": "sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==",
       "dev": true,
       "requires": {
-        "errno": "~0.1.7"
+        "errno": "0.1.7"
       }
     },
     "wrap-ansi": {
@@ -6258,8 +6310,8 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1"
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -6272,7 +6324,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "string-width": {
@@ -6280,9 +6332,9 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         },
         "strip-ansi": {
@@ -6290,7 +6342,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         }
       }
@@ -6323,16 +6375,16 @@
       "integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
       "dev": true,
       "requires": {
-        "cliui": "^5.0.0",
-        "find-up": "^3.0.0",
-        "get-caller-file": "^2.0.1",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^2.0.0",
-        "set-blocking": "^2.0.0",
-        "string-width": "^3.0.0",
-        "which-module": "^2.0.0",
-        "y18n": "^4.0.0",
-        "yargs-parser": "^13.1.1"
+        "cliui": "5.0.0",
+        "find-up": "3.0.0",
+        "get-caller-file": "2.0.5",
+        "require-directory": "2.1.1",
+        "require-main-filename": "2.0.0",
+        "set-blocking": "2.0.0",
+        "string-width": "3.1.0",
+        "which-module": "2.0.0",
+        "y18n": "4.0.0",
+        "yargs-parser": "13.1.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -6347,9 +6399,9 @@
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
+            "emoji-regex": "7.0.3",
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "5.2.0"
           }
         },
         "strip-ansi": {
@@ -6358,7 +6410,7 @@
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^4.1.0"
+            "ansi-regex": "4.1.0"
           }
         }
       }
@@ -6369,8 +6421,8 @@
       "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
       "dev": true,
       "requires": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
+        "camelcase": "5.3.1",
+        "decamelize": "1.2.0"
       }
     },
     "yargs-unparser": {
@@ -6379,9 +6431,9 @@
       "integrity": "sha512-W9tKgmSn0DpSatfri0nx52Joq5hVXgeLiqR/5G0sZNDoLZFOr/xjBUDcShCOGNsBnEMNo1KAMBkTej1Hm62HTw==",
       "dev": true,
       "requires": {
-        "flat": "^4.1.0",
-        "lodash": "^4.17.15",
-        "yargs": "^13.3.0"
+        "flat": "4.1.0",
+        "lodash": "4.17.15",
+        "yargs": "13.3.0"
       }
     },
     "yeoman-assert": {
@@ -6395,21 +6447,21 @@
       "resolved": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-2.8.0.tgz",
       "integrity": "sha512-BbJeEna23Qx90fBiJt1awcZ9okfPY/rP3xZYsk1rD3x8LuQgpo4BfegPvQT1sqqh2+gYVZmYZMv5pS8+Muyr9Q==",
       "requires": {
-        "chalk": "^2.4.1",
-        "cross-spawn": "^6.0.5",
-        "debug": "^3.1.0",
-        "diff": "^3.5.0",
-        "escape-string-regexp": "^1.0.2",
-        "globby": "^8.0.1",
-        "grouped-queue": "^1.0.0",
-        "inquirer": "^6.0.0",
-        "is-scoped": "^1.0.0",
-        "lodash": "^4.17.10",
-        "log-symbols": "^2.2.0",
-        "mem-fs": "^1.1.0",
-        "strip-ansi": "^4.0.0",
-        "text-table": "^0.2.0",
-        "untildify": "^3.0.3"
+        "chalk": "2.4.2",
+        "cross-spawn": "6.0.5",
+        "debug": "3.2.6",
+        "diff": "3.5.0",
+        "escape-string-regexp": "1.0.5",
+        "globby": "8.0.2",
+        "grouped-queue": "1.0.0",
+        "inquirer": "6.5.2",
+        "is-scoped": "1.0.0",
+        "lodash": "4.17.15",
+        "log-symbols": "2.2.0",
+        "mem-fs": "1.1.3",
+        "strip-ansi": "4.0.0",
+        "text-table": "0.2.0",
+        "untildify": "3.0.3"
       },
       "dependencies": {
         "debug": {
@@ -6417,7 +6469,7 @@
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
         },
         "ms": {
@@ -6432,31 +6484,31 @@
       "resolved": "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-3.2.0.tgz",
       "integrity": "sha512-iR/qb2je3GdXtSfxgvOXxUW0Cp8+C6LaZaNlK2BAICzFNzwHtM10t/QBwz5Ea9nk6xVDQNj4Q889TjCXGuIv8w==",
       "requires": {
-        "async": "^2.6.0",
-        "chalk": "^2.3.0",
-        "cli-table": "^0.3.1",
-        "cross-spawn": "^6.0.5",
-        "dargs": "^6.0.0",
-        "dateformat": "^3.0.3",
-        "debug": "^4.1.0",
-        "detect-conflict": "^1.0.0",
-        "error": "^7.0.2",
-        "find-up": "^3.0.0",
-        "github-username": "^4.0.0",
-        "istextorbinary": "^2.2.1",
-        "lodash": "^4.17.10",
-        "make-dir": "^1.1.0",
-        "mem-fs-editor": "^5.0.0",
-        "minimist": "^1.2.0",
-        "pretty-bytes": "^5.1.0",
-        "read-chunk": "^3.0.0",
-        "read-pkg-up": "^4.0.0",
-        "rimraf": "^2.6.2",
-        "run-async": "^2.0.0",
-        "shelljs": "^0.8.0",
-        "text-table": "^0.2.0",
-        "through2": "^3.0.0",
-        "yeoman-environment": "^2.0.5"
+        "async": "2.6.3",
+        "chalk": "2.4.2",
+        "cli-table": "0.3.1",
+        "cross-spawn": "6.0.5",
+        "dargs": "6.1.0",
+        "dateformat": "3.0.3",
+        "debug": "4.1.1",
+        "detect-conflict": "1.0.1",
+        "error": "7.2.1",
+        "find-up": "3.0.0",
+        "github-username": "4.1.0",
+        "istextorbinary": "2.6.0",
+        "lodash": "4.17.15",
+        "make-dir": "1.3.0",
+        "mem-fs-editor": "5.1.0",
+        "minimist": "1.2.0",
+        "pretty-bytes": "5.3.0",
+        "read-chunk": "3.2.0",
+        "read-pkg-up": "4.0.0",
+        "rimraf": "2.7.1",
+        "run-async": "2.4.0",
+        "shelljs": "0.8.3",
+        "text-table": "0.2.0",
+        "through2": "3.0.1",
+        "yeoman-environment": "2.8.0"
       },
       "dependencies": {
         "debug": {
@@ -6464,7 +6516,7 @@
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
         },
         "ms": {
@@ -6477,7 +6529,7 @@
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
           "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
           "requires": {
-            "glob": "^7.1.3"
+            "glob": "7.1.6"
           }
         }
       }
@@ -6488,14 +6540,14 @@
       "integrity": "sha512-aWB8CglmjBfXd+U5g5Cm1b8KVW0uotjo521IgkepvhNXiAX/YswHYGVnbEFb0m9ZdXztELuNJn2UtuwgFZIw6Q==",
       "dev": true,
       "requires": {
-        "inquirer": "^5.2.0",
-        "lodash": "^4.17.10",
-        "mkdirp": "^0.5.1",
-        "pinkie-promise": "^2.0.1",
-        "rimraf": "^2.4.4",
-        "sinon": "^5.0.7",
-        "yeoman-environment": "^2.3.0",
-        "yeoman-generator": "^2.0.5"
+        "inquirer": "5.2.0",
+        "lodash": "4.17.15",
+        "mkdirp": "0.5.1",
+        "pinkie-promise": "2.0.1",
+        "rimraf": "2.7.1",
+        "sinon": "5.1.1",
+        "yeoman-environment": "2.8.0",
+        "yeoman-generator": "2.0.5"
       },
       "dependencies": {
         "chardet": {
@@ -6516,7 +6568,7 @@
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
         },
         "external-editor": {
@@ -6525,9 +6577,9 @@
           "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
           "dev": true,
           "requires": {
-            "chardet": "^0.4.0",
-            "iconv-lite": "^0.4.17",
-            "tmp": "^0.0.33"
+            "chardet": "0.4.2",
+            "iconv-lite": "0.4.24",
+            "tmp": "0.0.33"
           }
         },
         "find-up": {
@@ -6536,7 +6588,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "2.0.0"
           }
         },
         "globby": {
@@ -6545,12 +6597,12 @@
           "integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
           "dev": true,
           "requires": {
-            "array-union": "^1.0.1",
-            "dir-glob": "^2.0.0",
-            "glob": "^7.1.2",
-            "ignore": "^3.3.5",
-            "pify": "^3.0.0",
-            "slash": "^1.0.0"
+            "array-union": "1.0.2",
+            "dir-glob": "2.0.0",
+            "glob": "7.1.6",
+            "ignore": "3.3.10",
+            "pify": "3.0.0",
+            "slash": "1.0.0"
           }
         },
         "inquirer": {
@@ -6559,19 +6611,19 @@
           "integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
           "dev": true,
           "requires": {
-            "ansi-escapes": "^3.0.0",
-            "chalk": "^2.0.0",
-            "cli-cursor": "^2.1.0",
-            "cli-width": "^2.0.0",
-            "external-editor": "^2.1.0",
-            "figures": "^2.0.0",
-            "lodash": "^4.3.0",
+            "ansi-escapes": "3.2.0",
+            "chalk": "2.4.2",
+            "cli-cursor": "2.1.0",
+            "cli-width": "2.2.0",
+            "external-editor": "2.2.0",
+            "figures": "2.0.0",
+            "lodash": "4.17.15",
             "mute-stream": "0.0.7",
-            "run-async": "^2.2.0",
-            "rxjs": "^5.5.2",
-            "string-width": "^2.1.0",
-            "strip-ansi": "^4.0.0",
-            "through": "^2.3.6"
+            "run-async": "2.4.0",
+            "rxjs": "5.5.12",
+            "string-width": "2.1.1",
+            "strip-ansi": "4.0.0",
+            "through": "2.3.8"
           }
         },
         "locate-path": {
@@ -6580,8 +6632,8 @@
           "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "dev": true,
           "requires": {
-            "p-locate": "^2.0.0",
-            "path-exists": "^3.0.0"
+            "p-locate": "2.0.0",
+            "path-exists": "3.0.0"
           }
         },
         "mem-fs-editor": {
@@ -6590,17 +6642,17 @@
           "integrity": "sha512-tgWmwI/+6vwu6POan82dTjxEpwAoaj0NAFnghtVo/FcLK2/7IhPUtFUUYlwou4MOY6OtjTUJtwpfH1h+eSUziw==",
           "dev": true,
           "requires": {
-            "commondir": "^1.0.1",
-            "deep-extend": "^0.6.0",
-            "ejs": "^2.5.9",
-            "glob": "^7.0.3",
-            "globby": "^7.1.1",
-            "isbinaryfile": "^3.0.2",
-            "mkdirp": "^0.5.0",
-            "multimatch": "^2.0.0",
-            "rimraf": "^2.2.8",
-            "through2": "^2.0.0",
-            "vinyl": "^2.0.1"
+            "commondir": "1.0.1",
+            "deep-extend": "0.6.0",
+            "ejs": "2.7.4",
+            "glob": "7.1.6",
+            "globby": "7.1.1",
+            "isbinaryfile": "3.0.3",
+            "mkdirp": "0.5.1",
+            "multimatch": "2.1.0",
+            "rimraf": "2.7.1",
+            "through2": "2.0.5",
+            "vinyl": "2.2.0"
           }
         },
         "ms": {
@@ -6615,7 +6667,7 @@
           "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
           "dev": true,
           "requires": {
-            "p-try": "^1.0.0"
+            "p-try": "1.0.0"
           }
         },
         "p-locate": {
@@ -6624,7 +6676,7 @@
           "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
           "dev": true,
           "requires": {
-            "p-limit": "^1.1.0"
+            "p-limit": "1.3.0"
           }
         },
         "p-try": {
@@ -6645,8 +6697,8 @@
           "integrity": "sha1-agTAkoAF7Z1C4aasVgDhnLx/9lU=",
           "dev": true,
           "requires": {
-            "pify": "^3.0.0",
-            "safe-buffer": "^5.1.1"
+            "pify": "3.0.0",
+            "safe-buffer": "5.2.0"
           }
         },
         "read-pkg-up": {
@@ -6655,8 +6707,8 @@
           "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
           "dev": true,
           "requires": {
-            "find-up": "^2.0.0",
-            "read-pkg": "^3.0.0"
+            "find-up": "2.1.0",
+            "read-pkg": "3.0.0"
           }
         },
         "rimraf": {
@@ -6665,7 +6717,7 @@
           "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
           "dev": true,
           "requires": {
-            "glob": "^7.1.3"
+            "glob": "7.1.6"
           }
         },
         "rxjs": {
@@ -6683,8 +6735,8 @@
           "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
           "dev": true,
           "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
+            "readable-stream": "2.3.7",
+            "xtend": "4.0.2"
           }
         },
         "yeoman-generator": {
@@ -6693,31 +6745,31 @@
           "integrity": "sha512-rV6tJ8oYzm4mmdF2T3wjY+Q42jKF2YiiD0VKfJ8/0ZYwmhCKC9Xs2346HVLPj/xE13i68psnFJv7iS6gWRkeAg==",
           "dev": true,
           "requires": {
-            "async": "^2.6.0",
-            "chalk": "^2.3.0",
-            "cli-table": "^0.3.1",
-            "cross-spawn": "^6.0.5",
-            "dargs": "^5.1.0",
-            "dateformat": "^3.0.3",
-            "debug": "^3.1.0",
-            "detect-conflict": "^1.0.0",
-            "error": "^7.0.2",
-            "find-up": "^2.1.0",
-            "github-username": "^4.0.0",
-            "istextorbinary": "^2.2.1",
-            "lodash": "^4.17.10",
-            "make-dir": "^1.1.0",
-            "mem-fs-editor": "^4.0.0",
-            "minimist": "^1.2.0",
-            "pretty-bytes": "^4.0.2",
-            "read-chunk": "^2.1.0",
-            "read-pkg-up": "^3.0.0",
-            "rimraf": "^2.6.2",
-            "run-async": "^2.0.0",
-            "shelljs": "^0.8.0",
-            "text-table": "^0.2.0",
-            "through2": "^2.0.0",
-            "yeoman-environment": "^2.0.5"
+            "async": "2.6.3",
+            "chalk": "2.4.2",
+            "cli-table": "0.3.1",
+            "cross-spawn": "6.0.5",
+            "dargs": "5.1.0",
+            "dateformat": "3.0.3",
+            "debug": "3.2.6",
+            "detect-conflict": "1.0.1",
+            "error": "7.2.1",
+            "find-up": "2.1.0",
+            "github-username": "4.1.0",
+            "istextorbinary": "2.6.0",
+            "lodash": "4.17.15",
+            "make-dir": "1.3.0",
+            "mem-fs-editor": "4.0.3",
+            "minimist": "1.2.0",
+            "pretty-bytes": "4.0.2",
+            "read-chunk": "2.1.0",
+            "read-pkg-up": "3.0.0",
+            "rimraf": "2.7.1",
+            "run-async": "2.4.0",
+            "shelljs": "0.8.3",
+            "text-table": "0.2.0",
+            "through2": "2.0.5",
+            "yeoman-environment": "2.8.0"
           }
         }
       }
@@ -6733,15 +6785,15 @@
       "resolved": "https://registry.npmjs.org/yosay/-/yosay-2.0.2.tgz",
       "integrity": "sha512-avX6nz2esp7IMXGag4gu6OyQBsMh/SEn+ZybGu3yKPlOTE6z9qJrzG/0X5vCq/e0rPFy0CUYCze0G5hL310ibA==",
       "requires": {
-        "ansi-regex": "^2.0.0",
-        "ansi-styles": "^3.0.0",
-        "chalk": "^1.0.0",
-        "cli-boxes": "^1.0.0",
+        "ansi-regex": "2.1.1",
+        "ansi-styles": "3.2.1",
+        "chalk": "1.1.3",
+        "cli-boxes": "1.0.0",
         "pad-component": "0.0.1",
-        "string-width": "^2.0.0",
-        "strip-ansi": "^3.0.0",
-        "taketalk": "^1.0.0",
-        "wrap-ansi": "^2.0.0"
+        "string-width": "2.1.1",
+        "strip-ansi": "3.0.1",
+        "taketalk": "1.0.0",
+        "wrap-ansi": "2.1.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -6754,11 +6806,11 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
           },
           "dependencies": {
             "ansi-styles": {
@@ -6773,7 +6825,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "supports-color": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2282,8 +2282,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2304,14 +2303,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2326,20 +2323,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2456,8 +2450,7 @@
         "inherits": {
           "version": "2.0.4",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2469,7 +2462,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2484,7 +2476,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2492,14 +2483,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2518,7 +2507,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2608,8 +2596,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2621,7 +2608,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2707,8 +2693,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2744,7 +2729,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2764,7 +2748,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2808,14 +2791,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "generators/app/index.js",
   "scripts": {
     "build": "node_modules/.bin/webpack",
-    "test": "rimraf temp-templates/* && npm run build && mocha -r ts-node/register tests/**/*.spec.ts --grep \"unit tests -\" --timeout 15000",
-    "test-integration": "rimraf temp-templates/* && npm run build && mocha -r ts-node/register tests/**/*.spec.ts --grep \"integration tests -\" --timeout 600s"
+    "test": "export TEST_TYPE=UNIT || SET TEST_TYPE=UNIT && rimraf temp-templates/* && npm run build && mocha -r ts-node/register tests/**/*.spec.ts --timeout 15000",
+    "test-integration": "export TEST_TYPE=INTEGRATION || SET TEST_TYPE=INTEGRATION && rimraf temp-templates/* && npm run build && mocha -r ts-node/register tests/**/*.spec.ts --timeout 600s"
   },
   "files": [
     "generators"

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "generators/app/index.js",
   "scripts": {
     "build": "node_modules/.bin/webpack",
-    "test": "export TEST_TYPE=UNIT || SET TEST_TYPE=UNIT && rimraf temp-templates/* && npm run build && mocha -r ts-node/register tests/**/*.spec.ts --timeout 15000",
-    "test-integration": "export TEST_TYPE=INTEGRATION || SET TEST_TYPE=INTEGRATION && rimraf temp-templates/* && npm run build && mocha -r ts-node/register tests/**/*.spec.ts --timeout 600s"
+    "test": "rimraf temp-templates/* && npm run build && cross-env TEST_TYPE=UNIT mocha -r ts-node/register tests/**/*.spec.ts --timeout 15000",
+    "test-integration": "rimraf temp-templates/* && npm run build && cross-env TEST_TYPE=INTEGRATION mocha -r ts-node/register tests/**/*.spec.ts --timeout 600s"
   },
   "files": [
     "generators"
@@ -69,6 +69,7 @@
     "chai": "^4.2.0",
     "clean-webpack-plugin": "^2.0.1",
     "copy-webpack-plugin": "^5.0.2",
+    "cross-env": "^7.0.2",
     "del": "^4.1.0",
     "fs-extra": "^7.0.1",
     "mocha": "^6.1.4",

--- a/tests/BotGenerator.spec.ts
+++ b/tests/BotGenerator.spec.ts
@@ -1,330 +1,461 @@
-import * as path from 'path';
-import * as del from 'del';
-import * as fs from 'fs-extra';
-import * as helpers from 'yeoman-test';
-import * as assert from 'yeoman-assert';
-import { describe, it } from 'mocha';
+import * as del from "del";
+import * as helpers from "yeoman-test";
+import * as assert from "yeoman-assert";
+import { describe, it } from "mocha";
 
-import * as testHelper from './helpers/TestHelper';
+import * as testHelper from "./helpers/TestHelper";
 
-describe('unit tests - teams:bot', async () => {
+describe("teams:bot", async () => {
+  const BOT_HTML_FILES = ["src/app/web/bottest01Bot/aboutBottest01Bot.html"];
 
-    const BOT_HTML_FILES = [
-        'src/app/web/bottest01Bot/aboutBottest01Bot.html'
-    ];
+  const BOT_SCRIPT_FILES = [
+    "src/app/scripts/bottest01Bot/AboutBottest01BotTab.tsx"
+  ];
 
-    const BOT_SCRIPT_FILES = [
-        'src/app/scripts/bottest01Bot/AboutBottest01BotTab.tsx'
-    ];
+  const BOT_SCRIPT_TEST_FILES = [
+    "src/app/scripts/bottest01Bot/__tests__/AboutBottest01BotTab.spec.tsx"
+  ];
 
-    const BOT_SCRIPT_TEST_FILES = [
-        'src/app/scripts/bottest01Bot/__tests__/AboutBottest01BotTab.spec.tsx'
-    ];
+  const BOT_FILES = [
+    "src/app/bottest01Bot/Bottest01Bot.ts",
+    "src/app/bottest01Bot/dialogs/HelpDialog.ts",
+    "src/app/bottest01Bot/dialogs/WelcomeDialog.ts",
+    "src/app/bottest01Bot/dialogs/WelcomeCard.json"
+  ];
 
-    const BOT_FILES = [
-        'src/app/bottest01Bot/Bottest01Bot.ts',
-        'src/app/bottest01Bot/dialogs/HelpDialog.ts',
-        'src/app/bottest01Bot/dialogs/WelcomeDialog.ts',
-        'src/app/bottest01Bot/dialogs/WelcomeCard.json'
-    ];
+  beforeEach(async () => {
+    await del([testHelper.TEMP_GENERATOR_PATTERN]);
+  });
 
-    beforeEach(async () => {
-        await del([testHelper.TEMP_GENERATOR_PATTERN]);
+  it("should generate bot project with v1.3 with unit tests", async () => {
+    const projectPath = testHelper.TEMP_BOT_GENERATOR_PATH + "/bot01-v13-withUnitT";
+
+    await helpers
+      .run(testHelper.GENERATOR_PATH)
+      .inDir(projectPath)
+      .withArguments(["--no-telemetry"])
+      .withPrompts({
+        solutionName: "bot-test-01",
+        whichFolder: "current",
+        name: "bottest01",
+        developer: "generator teams developer",
+        manifestVersion: "v1.3",
+        parts: "bot",
+        unitTestsEnabled: true
+      })
+      .withGenerators(testHelper.DEPENDENCIES);
+
+    assert.file(testHelper.ROOT_FILES);
+    assert.file(testHelper.TEST_FILES);
+    assert.file(testHelper.APP_FILES);
+    assert.file(testHelper.SCRIPT_FILES);
+    assert.file(testHelper.WEB_FILES);
+    assert.file(testHelper.MANIFEST_FILES);
+    assert.fileContent("src/manifest/manifest.json", testHelper.SCHEMA_13);
+
+    assert.file(BOT_SCRIPT_FILES);
+    assert.file(BOT_SCRIPT_TEST_FILES);
+    assert.file(BOT_FILES);
+    assert.file(BOT_HTML_FILES);
+
+    if (process.env.TEST_TYPE == testHelper.TestTypes.INTEGRATION) {
+      const npmInstallResult = await testHelper.runNpmCommand("npm install", projectPath);
+      assert.equal(false, npmInstallResult);
+
+      const npmRunBuildResult = await testHelper.runNpmCommand("npm run build", projectPath);
+      assert.equal(false, npmRunBuildResult);
+
+      const npmRunTestResult = await testHelper.runNpmCommand("npm run test", projectPath);
+      assert.equal(false, npmRunTestResult);
+    }
+  });
+
+  it("should generate bot project with v1.3 without unit tests", async () => {
+    const projectPath = testHelper.TEMP_BOT_GENERATOR_PATH + "/bot01-v13-withoutUnitT";
+
+    await helpers
+      .run(testHelper.GENERATOR_PATH)
+      .inDir(projectPath)
+      .withArguments(["--no-telemetry"])
+      .withPrompts({
+        solutionName: "bot-test-01",
+        whichFolder: "current",
+        name: "bottest01",
+        developer: "generator teams developer",
+        manifestVersion: "v1.3",
+        parts: "bot",
+        unitTestsEnabled: false
+      })
+      .withGenerators(testHelper.DEPENDENCIES);
+
+    assert.file(testHelper.ROOT_FILES);
+    assert.noFile(testHelper.TEST_FILES);
+    assert.file(testHelper.APP_FILES);
+    assert.file(testHelper.SCRIPT_FILES);
+    assert.file(testHelper.WEB_FILES);
+    assert.file(testHelper.MANIFEST_FILES);
+    assert.fileContent("src/manifest/manifest.json", testHelper.SCHEMA_13);
+
+    assert.file(BOT_SCRIPT_FILES);
+    assert.noFile(BOT_SCRIPT_TEST_FILES);
+    assert.file(BOT_FILES);
+    assert.file(BOT_HTML_FILES);
+
+    if (process.env.TEST_TYPE == testHelper.TestTypes.INTEGRATION) {
+      const npmInstallResult = await testHelper.runNpmCommand("npm install", projectPath);
+      assert.equal(false, npmInstallResult);
+
+      const npmRunBuildResult = await testHelper.runNpmCommand("npm run build", projectPath);
+      assert.equal(false, npmRunBuildResult);
+    }
+  });
+
+  it("should generate bot project with v1.4 with unit tests", async () => {
+    const projectPath = testHelper.TEMP_BOT_GENERATOR_PATH + "/bot01-v14-withUnitT";
+
+    await helpers
+      .run(testHelper.GENERATOR_PATH)
+      .inDir(projectPath)
+      .withArguments(["--no-telemetry"])
+      .withPrompts({
+        solutionName: "bot-test-01",
+        whichFolder: "current",
+        name: "bottest01",
+        developer: "generator teams developer",
+        manifestVersion: "v1.4",
+        parts: "bot",
+        unitTestsEnabled: true
+      })
+      .withGenerators(testHelper.DEPENDENCIES);
+
+    assert.file(testHelper.ROOT_FILES);
+    assert.file(testHelper.TEST_FILES);
+    assert.file(testHelper.APP_FILES);
+    assert.file(testHelper.SCRIPT_FILES);
+    assert.file(testHelper.WEB_FILES);
+    assert.file(testHelper.MANIFEST_FILES);
+    assert.fileContent("src/manifest/manifest.json", testHelper.SCHEMA_14);
+
+    assert.file(BOT_SCRIPT_FILES);
+    assert.file(BOT_SCRIPT_TEST_FILES);
+    assert.file(BOT_FILES);
+    assert.file(BOT_HTML_FILES);
+
+    if (process.env.TEST_TYPE == testHelper.TestTypes.INTEGRATION) {
+      const npmInstallResult = await testHelper.runNpmCommand("npm install", projectPath);
+      assert.equal(false, npmInstallResult);
+
+      const npmRunBuildResult = await testHelper.runNpmCommand("npm run build", projectPath);
+      assert.equal(false, npmRunBuildResult);
+
+      const npmRunTestResult = await testHelper.runNpmCommand("npm run test", projectPath);
+      assert.equal(false, npmRunTestResult);
+    }
+  });
+
+  it("should generate bot project with v1.4 without unit tests", async () => {
+    const projectPath = testHelper.TEMP_BOT_GENERATOR_PATH + "/bot01-v14-withoutUnitT";
+
+    await helpers
+      .run(testHelper.GENERATOR_PATH)
+      .inDir(projectPath)
+      .withArguments(["--no-telemetry"])
+      .withPrompts({
+        solutionName: "bot-test-01",
+        whichFolder: "current",
+        name: "bottest01",
+        developer: "generator teams developer",
+        manifestVersion: "v1.4",
+        parts: "bot",
+        unitTestsEnabled: false
+      })
+      .withGenerators(testHelper.DEPENDENCIES);
+
+    assert.file(testHelper.ROOT_FILES);
+    assert.noFile(testHelper.TEST_FILES);
+    assert.file(testHelper.APP_FILES);
+    assert.file(testHelper.SCRIPT_FILES);
+    assert.file(testHelper.WEB_FILES);
+    assert.file(testHelper.MANIFEST_FILES);
+    assert.fileContent("src/manifest/manifest.json", testHelper.SCHEMA_14);
+    assert.noJsonFileContent("src/manifest/manifest.json", {
+      bots: [{ supportsFiles: true }]
     });
 
-    it('should generate bot project with v1.3 with unit tests', async () => {
-        await helpers.run(testHelper.GENERATOR_PATH)
-            .inDir(testHelper.TEMP_BOT_GENERATOR_PATH + '/bot01')
-            .withArguments(['--no-telemetry'])
-            .withPrompts({
-                solutionName: 'bot-test-01',
-                whichFolder: 'current',
-                name: 'bottest01',
-                developer: 'generator teams developer',
-                manifestVersion: 'v1.3',
-                parts: 'bot',
-                unitTestsEnabled: true,
-            })
-            .withGenerators(testHelper.DEPENDENCIES);
+    assert.file(BOT_SCRIPT_FILES);
+    assert.noFile(BOT_SCRIPT_TEST_FILES);
+    assert.file(BOT_FILES);
+    assert.file(BOT_HTML_FILES);
 
-        assert.file(testHelper.ROOT_FILES);
-        assert.file(testHelper.TEST_FILES);
-        assert.file(testHelper.APP_FILES);
-        assert.file(testHelper.SCRIPT_FILES);
-        assert.file(testHelper.WEB_FILES);
-        assert.file(testHelper.MANIFEST_FILES);
-        assert.fileContent('src/manifest/manifest.json', testHelper.SCHEMA_13);
+    if (process.env.TEST_TYPE == testHelper.TestTypes.INTEGRATION) {
+      const npmInstallResult = await testHelper.runNpmCommand("npm install", projectPath);
+      assert.equal(false, npmInstallResult);
 
-        assert.file(BOT_SCRIPT_FILES);
-        assert.file(BOT_SCRIPT_TEST_FILES);
-        assert.file(BOT_FILES);
-        assert.file(BOT_HTML_FILES);
+      const npmRunBuildResult = await testHelper.runNpmCommand("npm run build", projectPath);
+      assert.equal(false, npmRunBuildResult);
+    }
+  });
+
+  it("should generate bot project with v1.4 without unit tests, and files support", async () => {
+    const projectPath = testHelper.TEMP_BOT_GENERATOR_PATH + "/bot01-v14-withoutUnitTAndFiles";
+
+    await helpers
+      .run(testHelper.GENERATOR_PATH)
+      .inDir(projectPath)
+      .withArguments(["--no-telemetry"])
+      .withPrompts({
+        solutionName: "bot-test-01",
+        whichFolder: "current",
+        name: "bottest01",
+        developer: "generator teams developer",
+        manifestVersion: "v1.4",
+        parts: "bot",
+        unitTestsEnabled: false,
+        botFilesEnabled: true
+      })
+      .withGenerators(testHelper.DEPENDENCIES);
+
+    assert.file(testHelper.ROOT_FILES);
+    assert.noFile(testHelper.TEST_FILES);
+    assert.file(testHelper.APP_FILES);
+    assert.file(testHelper.SCRIPT_FILES);
+    assert.file(testHelper.WEB_FILES);
+    assert.file(testHelper.MANIFEST_FILES);
+    assert.fileContent("src/manifest/manifest.json", testHelper.SCHEMA_14);
+    assert.jsonFileContent("src/manifest/manifest.json", {
+      bots: [{ supportsFiles: true }]
     });
 
-    it('should generate bot project with v1.3 without unit tests', async () => {
-        await helpers.run(testHelper.GENERATOR_PATH)
-            .inDir(testHelper.TEMP_BOT_GENERATOR_PATH + '/bot02')
-            .withArguments(['--no-telemetry'])
-            .withPrompts({
-                solutionName: 'bot-test-01',
-                whichFolder: 'current',
-                name: 'bottest01',
-                developer: 'generator teams developer',
-                manifestVersion: 'v1.3',
-                parts: 'bot',
-                unitTestsEnabled: false
-            })
-            .withGenerators(testHelper.DEPENDENCIES);
+    assert.file(BOT_SCRIPT_FILES);
+    assert.noFile(BOT_SCRIPT_TEST_FILES);
+    assert.file(BOT_FILES);
+    assert.file(BOT_HTML_FILES);
 
-        assert.file(testHelper.ROOT_FILES);
-        assert.noFile(testHelper.TEST_FILES);
-        assert.file(testHelper.APP_FILES);
-        assert.file(testHelper.SCRIPT_FILES);
-        assert.file(testHelper.WEB_FILES);
-        assert.file(testHelper.MANIFEST_FILES);
-        assert.fileContent('src/manifest/manifest.json', testHelper.SCHEMA_13);
+    if (process.env.TEST_TYPE == testHelper.TestTypes.INTEGRATION) {
+      const npmInstallResult = await testHelper.runNpmCommand("npm install", projectPath);
+      assert.equal(false, npmInstallResult);
 
-        assert.file(BOT_SCRIPT_FILES);
-        assert.noFile(BOT_SCRIPT_TEST_FILES);
-        assert.file(BOT_FILES);
-        assert.file(BOT_HTML_FILES);
+      const npmRunBuildResult = await testHelper.runNpmCommand("npm run build", projectPath);
+      assert.equal(false, npmRunBuildResult);
+    }
+  });
+
+  it("should generate bot project with v1.5 with unit tests", async () => {
+    const projectPath = testHelper.TEMP_BOT_GENERATOR_PATH + "/bot01-v15-withUnitT";
+
+    await helpers
+      .run(testHelper.GENERATOR_PATH)
+      .inDir(projectPath)
+      .withArguments(["--no-telemetry"])
+      .withPrompts({
+        solutionName: "bot-test-01",
+        whichFolder: "current",
+        name: "bottest01",
+        developer: "generator teams developer",
+        manifestVersion: "v1.5",
+        parts: "bot",
+        unitTestsEnabled: true
+      })
+      .withGenerators(testHelper.DEPENDENCIES);
+
+    assert.file(testHelper.ROOT_FILES);
+    assert.file(testHelper.TEST_FILES);
+    assert.file(testHelper.APP_FILES);
+    assert.file(testHelper.SCRIPT_FILES);
+    assert.file(testHelper.WEB_FILES);
+    assert.file(testHelper.MANIFEST_FILES);
+    assert.fileContent("src/manifest/manifest.json", testHelper.SCHEMA_15);
+
+    assert.file(BOT_SCRIPT_FILES);
+    assert.file(BOT_SCRIPT_TEST_FILES);
+    assert.file(BOT_FILES);
+    assert.file(BOT_HTML_FILES);
+
+    if (process.env.TEST_TYPE == testHelper.TestTypes.INTEGRATION) {
+      const npmInstallResult = await testHelper.runNpmCommand("npm install", projectPath);
+      assert.equal(false, npmInstallResult);
+
+      const npmRunBuildResult = await testHelper.runNpmCommand("npm run build", projectPath);
+      assert.equal(false, npmRunBuildResult);
+
+      const npmRunTestResult = await testHelper.runNpmCommand("npm run test", projectPath);
+      assert.equal(false, npmRunTestResult);
+    }
+  });
+
+  it("should generate bot project with v1.5 without unit tests", async () => {
+    const projectPath = testHelper.TEMP_BOT_GENERATOR_PATH + "/bot01-v15-withoutUnitT";
+
+    await helpers
+      .run(testHelper.GENERATOR_PATH)
+      .inDir(projectPath)
+      .withArguments(["--no-telemetry"])
+      .withPrompts({
+        solutionName: "bot-test-01",
+        whichFolder: "current",
+        name: "bottest01",
+        developer: "generator teams developer",
+        manifestVersion: "v1.5",
+        parts: "bot",
+        unitTestsEnabled: false
+      })
+      .withGenerators(testHelper.DEPENDENCIES);
+
+    assert.file(testHelper.ROOT_FILES);
+    assert.noFile(testHelper.TEST_FILES);
+    assert.file(testHelper.APP_FILES);
+    assert.file(testHelper.SCRIPT_FILES);
+    assert.file(testHelper.WEB_FILES);
+    assert.file(testHelper.MANIFEST_FILES);
+    assert.fileContent("src/manifest/manifest.json", testHelper.SCHEMA_15);
+    assert.noJsonFileContent("src/manifest/manifest.json", {
+      bots: [{ supportsFiles: true }]
     });
 
-    it('should generate bot project with v1.4 with unit tests', async () => {
-        await helpers.run(testHelper.GENERATOR_PATH)
-            .inDir(testHelper.TEMP_BOT_GENERATOR_PATH + '/bot01-14')
-            .withArguments(['--no-telemetry'])
-            .withPrompts({
-                solutionName: 'bot-test-01',
-                whichFolder: 'current',
-                name: 'bottest01',
-                developer: 'generator teams developer',
-                manifestVersion: 'v1.4',
-                parts: 'bot',
-                unitTestsEnabled: true,
-            })
-            .withGenerators(testHelper.DEPENDENCIES);
+    assert.file(BOT_SCRIPT_FILES);
+    assert.noFile(BOT_SCRIPT_TEST_FILES);
+    assert.file(BOT_FILES);
+    assert.file(BOT_HTML_FILES);
 
-        assert.file(testHelper.ROOT_FILES);
-        assert.file(testHelper.TEST_FILES);
-        assert.file(testHelper.APP_FILES);
-        assert.file(testHelper.SCRIPT_FILES);
-        assert.file(testHelper.WEB_FILES);
-        assert.file(testHelper.MANIFEST_FILES);
-        assert.fileContent('src/manifest/manifest.json', testHelper.SCHEMA_14);
+    if (process.env.TEST_TYPE == testHelper.TestTypes.INTEGRATION) {
+      const npmInstallResult = await testHelper.runNpmCommand("npm install", projectPath);
+      assert.equal(false, npmInstallResult);
 
-        assert.file(BOT_SCRIPT_FILES);
-        assert.file(BOT_SCRIPT_TEST_FILES);
-        assert.file(BOT_FILES);
-        assert.file(BOT_HTML_FILES);
+      const npmRunBuildResult = await testHelper.runNpmCommand("npm run build", projectPath);
+      assert.equal(false, npmRunBuildResult);
+    }
+  });
+
+  it("should generate bot project with v1.5 without unit tests, and files support", async () => {
+    const projectPath = testHelper.TEMP_BOT_GENERATOR_PATH + "/bot01-v15-withoutUnitTAndFiles";
+
+    await helpers
+      .run(testHelper.GENERATOR_PATH)
+      .inDir(projectPath)
+      .withArguments(["--no-telemetry"])
+      .withPrompts({
+        solutionName: "bot-test-01",
+        whichFolder: "current",
+        name: "bottest01",
+        developer: "generator teams developer",
+        manifestVersion: "v1.5",
+        parts: "bot",
+        unitTestsEnabled: false,
+        botFilesEnabled: true
+      })
+      .withGenerators(testHelper.DEPENDENCIES);
+
+    assert.file(testHelper.ROOT_FILES);
+    assert.noFile(testHelper.TEST_FILES);
+    assert.file(testHelper.APP_FILES);
+    assert.file(testHelper.SCRIPT_FILES);
+    assert.file(testHelper.WEB_FILES);
+    assert.file(testHelper.MANIFEST_FILES);
+    assert.fileContent("src/manifest/manifest.json", testHelper.SCHEMA_15);
+    assert.jsonFileContent("src/manifest/manifest.json", {
+      bots: [{ supportsFiles: true }]
     });
 
-    it('should generate bot project with v1.4 without unit tests', async () => {
-        await helpers.run(testHelper.GENERATOR_PATH)
-            .inDir(testHelper.TEMP_BOT_GENERATOR_PATH + '/bot02-14')
-            .withArguments(['--no-telemetry'])
-            .withPrompts({
-                solutionName: 'bot-test-01',
-                whichFolder: 'current',
-                name: 'bottest01',
-                developer: 'generator teams developer',
-                manifestVersion: 'v1.4',
-                parts: 'bot',
-                unitTestsEnabled: false
-            })
-            .withGenerators(testHelper.DEPENDENCIES);
+    assert.file(BOT_SCRIPT_FILES);
+    assert.noFile(BOT_SCRIPT_TEST_FILES);
+    assert.file(BOT_FILES);
+    assert.file(BOT_HTML_FILES);
 
-        assert.file(testHelper.ROOT_FILES);
-        assert.noFile(testHelper.TEST_FILES);
-        assert.file(testHelper.APP_FILES);
-        assert.file(testHelper.SCRIPT_FILES);
-        assert.file(testHelper.WEB_FILES);
-        assert.file(testHelper.MANIFEST_FILES);
-        assert.fileContent('src/manifest/manifest.json', testHelper.SCHEMA_14);
-        assert.noJsonFileContent('src/manifest/manifest.json', { bots: [{ supportsFiles: true }] });
+    if (process.env.TEST_TYPE == testHelper.TestTypes.INTEGRATION) {
+      const npmInstallResult = await testHelper.runNpmCommand("npm install", projectPath);
+      assert.equal(false, npmInstallResult);
 
-        assert.file(BOT_SCRIPT_FILES);
-        assert.noFile(BOT_SCRIPT_TEST_FILES);
-        assert.file(BOT_FILES);
-        assert.file(BOT_HTML_FILES);
-    });
+      const npmRunBuildResult = await testHelper.runNpmCommand("npm run build", projectPath);
+      assert.equal(false, npmRunBuildResult);
+    }
+  });
 
-    it('should generate bot project with v1.4 without unit tests, and files support', async () => {
-        await helpers.run(testHelper.GENERATOR_PATH)
-            .inDir(testHelper.TEMP_BOT_GENERATOR_PATH + '/bot02-14-files')
-            .withArguments(['--no-telemetry'])
-            .withPrompts({
-                solutionName: 'bot-test-01',
-                whichFolder: 'current',
-                name: 'bottest01',
-                developer: 'generator teams developer',
-                manifestVersion: 'v1.4',
-                parts: 'bot',
-                unitTestsEnabled: false,
-                botFilesEnabled: true
-            })
-            .withGenerators(testHelper.DEPENDENCIES);
+  it("should generate bot project with devPreview with unit tests", async () => {
+    const projectPath = testHelper.TEMP_BOT_GENERATOR_PATH + "/bot01-devPrev-withUnitT";
 
-        assert.file(testHelper.ROOT_FILES);
-        assert.noFile(testHelper.TEST_FILES);
-        assert.file(testHelper.APP_FILES);
-        assert.file(testHelper.SCRIPT_FILES);
-        assert.file(testHelper.WEB_FILES);
-        assert.file(testHelper.MANIFEST_FILES);
-        assert.fileContent('src/manifest/manifest.json', testHelper.SCHEMA_14);
-        assert.jsonFileContent('src/manifest/manifest.json', { bots: [{ supportsFiles: true }] });
+    await helpers
+      .run(testHelper.GENERATOR_PATH)
+      .inDir(projectPath)
+      .withArguments(["--no-telemetry"])
+      .withPrompts({
+        solutionName: "bot-test-01",
+        whichFolder: "current",
+        name: "bottest01",
+        developer: "generator teams developer",
+        manifestVersion: "devPreview",
+        parts: "bot",
+        unitTestsEnabled: true
+      })
+      .withGenerators(testHelper.DEPENDENCIES);
 
-        assert.file(BOT_SCRIPT_FILES);
-        assert.noFile(BOT_SCRIPT_TEST_FILES);
-        assert.file(BOT_FILES);
-        assert.file(BOT_HTML_FILES);
-    });
+    assert.file(testHelper.ROOT_FILES);
+    assert.file(testHelper.TEST_FILES);
+    assert.file(testHelper.APP_FILES);
+    assert.file(testHelper.SCRIPT_FILES);
+    assert.file(testHelper.WEB_FILES);
+    assert.file(testHelper.MANIFEST_FILES);
+    assert.fileContent(
+      "src/manifest/manifest.json",
+      testHelper.SCHEMA_DEVPREVIEW
+    );
 
-    it('should generate bot project with v1.5 with unit tests', async () => {
-        await helpers.run(testHelper.GENERATOR_PATH)
-            .inDir(testHelper.TEMP_BOT_GENERATOR_PATH + '/bot01-15')
-            .withArguments(['--no-telemetry'])
-            .withPrompts({
-                solutionName: 'bot-test-01',
-                whichFolder: 'current',
-                name: 'bottest01',
-                developer: 'generator teams developer',
-                manifestVersion: 'v1.5',
-                parts: 'bot',
-                unitTestsEnabled: true,
-            })
-            .withGenerators(testHelper.DEPENDENCIES);
+    assert.file(BOT_SCRIPT_FILES);
+    assert.file(BOT_SCRIPT_TEST_FILES);
+    assert.file(BOT_FILES);
+    assert.file(BOT_HTML_FILES);
 
-        assert.file(testHelper.ROOT_FILES);
-        assert.file(testHelper.TEST_FILES);
-        assert.file(testHelper.APP_FILES);
-        assert.file(testHelper.SCRIPT_FILES);
-        assert.file(testHelper.WEB_FILES);
-        assert.file(testHelper.MANIFEST_FILES);
-        assert.fileContent('src/manifest/manifest.json', testHelper.SCHEMA_15);
+    if (process.env.TEST_TYPE == testHelper.TestTypes.INTEGRATION) {
+      const npmInstallResult = await testHelper.runNpmCommand("npm install", projectPath);
+      assert.equal(false, npmInstallResult);
 
-        assert.file(BOT_SCRIPT_FILES);
-        assert.file(BOT_SCRIPT_TEST_FILES);
-        assert.file(BOT_FILES);
-        assert.file(BOT_HTML_FILES);
-    });
+      const npmRunBuildResult = await testHelper.runNpmCommand("npm run build", projectPath);
+      assert.equal(false, npmRunBuildResult);
 
-    it('should generate bot project with v1.5 without unit tests', async () => {
-        await helpers.run(testHelper.GENERATOR_PATH)
-            .inDir(testHelper.TEMP_BOT_GENERATOR_PATH + '/bot02-15')
-            .withArguments(['--no-telemetry'])
-            .withPrompts({
-                solutionName: 'bot-test-01',
-                whichFolder: 'current',
-                name: 'bottest01',
-                developer: 'generator teams developer',
-                manifestVersion: 'v1.5',
-                parts: 'bot',
-                unitTestsEnabled: false
-            })
-            .withGenerators(testHelper.DEPENDENCIES);
+      const npmRunTestResult = await testHelper.runNpmCommand("npm run test", projectPath);
+      assert.equal(false, npmRunTestResult);
+    }
+  });
 
-        assert.file(testHelper.ROOT_FILES);
-        assert.noFile(testHelper.TEST_FILES);
-        assert.file(testHelper.APP_FILES);
-        assert.file(testHelper.SCRIPT_FILES);
-        assert.file(testHelper.WEB_FILES);
-        assert.file(testHelper.MANIFEST_FILES);
-        assert.fileContent('src/manifest/manifest.json', testHelper.SCHEMA_15);
-        assert.noJsonFileContent('src/manifest/manifest.json', { bots: [{ supportsFiles: true }] });
+  it("should generate bot project with devPreview without unit tests", async () => {
+    const projectPath = testHelper.TEMP_BOT_GENERATOR_PATH + "/bot01-devPrev-withoutUnitT";
 
-        assert.file(BOT_SCRIPT_FILES);
-        assert.noFile(BOT_SCRIPT_TEST_FILES);
-        assert.file(BOT_FILES);
-        assert.file(BOT_HTML_FILES);
-    });
+    await helpers
+      .run(testHelper.GENERATOR_PATH)
+      .inDir(projectPath)
+      .withArguments(["--no-telemetry"])
+      .withPrompts({
+        solutionName: "bot-test-01",
+        whichFolder: "current",
+        name: "bottest01",
+        developer: "generator teams developer",
+        manifestVersion: "devPreview",
+        parts: "bot",
+        unitTestsEnabled: false
+      })
+      .withGenerators(testHelper.DEPENDENCIES);
 
-    it('should generate bot project with v1.5 without unit tests, and files support', async () => {
-        await helpers.run(testHelper.GENERATOR_PATH)
-            .inDir(testHelper.TEMP_BOT_GENERATOR_PATH + '/bot02-15-files')
-            .withArguments(['--no-telemetry'])
-            .withPrompts({
-                solutionName: 'bot-test-01',
-                whichFolder: 'current',
-                name: 'bottest01',
-                developer: 'generator teams developer',
-                manifestVersion: 'v1.5',
-                parts: 'bot',
-                unitTestsEnabled: false,
-                botFilesEnabled: true
-            })
-            .withGenerators(testHelper.DEPENDENCIES);
+    assert.file(testHelper.ROOT_FILES);
+    assert.noFile(testHelper.TEST_FILES);
+    assert.file(testHelper.APP_FILES);
+    assert.file(testHelper.SCRIPT_FILES);
+    assert.file(testHelper.WEB_FILES);
+    assert.file(testHelper.MANIFEST_FILES);
+    assert.fileContent(
+      "src/manifest/manifest.json",
+      testHelper.SCHEMA_DEVPREVIEW
+    );
 
-        assert.file(testHelper.ROOT_FILES);
-        assert.noFile(testHelper.TEST_FILES);
-        assert.file(testHelper.APP_FILES);
-        assert.file(testHelper.SCRIPT_FILES);
-        assert.file(testHelper.WEB_FILES);
-        assert.file(testHelper.MANIFEST_FILES);
-        assert.fileContent('src/manifest/manifest.json', testHelper.SCHEMA_15);
-        assert.jsonFileContent('src/manifest/manifest.json', { bots: [{ supportsFiles: true }] });
+    assert.file(BOT_SCRIPT_FILES);
+    assert.noFile(BOT_SCRIPT_TEST_FILES);
+    assert.file(BOT_FILES);
+    assert.file(BOT_HTML_FILES);
 
-        assert.file(BOT_SCRIPT_FILES);
-        assert.noFile(BOT_SCRIPT_TEST_FILES);
-        assert.file(BOT_FILES);
-        assert.file(BOT_HTML_FILES);
-    });
+    if (process.env.TEST_TYPE == testHelper.TestTypes.INTEGRATION) {
+      const npmInstallResult = await testHelper.runNpmCommand("npm install", projectPath);
+      assert.equal(false, npmInstallResult);
 
-    it('should generate bot project with devPreview with unit tests', async () => {
-        await helpers.run(testHelper.GENERATOR_PATH)
-            .inDir(testHelper.TEMP_BOT_GENERATOR_PATH + '/bot03')
-            .withArguments(['--no-telemetry'])
-            .withPrompts({
-                solutionName: 'bot-test-01',
-                whichFolder: 'current',
-                name: 'bottest01',
-                developer: 'generator teams developer',
-                manifestVersion: 'devPreview',
-                parts: 'bot',
-                unitTestsEnabled: true
-            })
-            .withGenerators(testHelper.DEPENDENCIES);
-
-        assert.file(testHelper.ROOT_FILES);
-        assert.file(testHelper.TEST_FILES);
-        assert.file(testHelper.APP_FILES);
-        assert.file(testHelper.SCRIPT_FILES);
-        assert.file(testHelper.WEB_FILES);
-        assert.file(testHelper.MANIFEST_FILES);
-        assert.fileContent('src/manifest/manifest.json', testHelper.SCHEMA_DEVPREVIEW);
-
-        assert.file(BOT_SCRIPT_FILES);
-        assert.file(BOT_SCRIPT_TEST_FILES);
-        assert.file(BOT_FILES);
-        assert.file(BOT_HTML_FILES);
-    });
-
-    it('should generate bot project with devPreview without unit tests', async () => {
-        await helpers.run(testHelper.GENERATOR_PATH)
-            .inDir(testHelper.TEMP_BOT_GENERATOR_PATH + '/bot04')
-            .withArguments(['--no-telemetry'])
-            .withPrompts({
-                solutionName: 'bot-test-01',
-                whichFolder: 'current',
-                name: 'bottest01',
-                developer: 'generator teams developer',
-                manifestVersion: 'devPreview',
-                parts: 'bot',
-                unitTestsEnabled: false
-            })
-            .withGenerators(testHelper.DEPENDENCIES);
-
-        assert.file(testHelper.ROOT_FILES);
-        assert.noFile(testHelper.TEST_FILES);
-        assert.file(testHelper.APP_FILES);
-        assert.file(testHelper.SCRIPT_FILES);
-        assert.file(testHelper.WEB_FILES);
-        assert.file(testHelper.MANIFEST_FILES);
-        assert.fileContent('src/manifest/manifest.json', testHelper.SCHEMA_DEVPREVIEW);
-
-        assert.file(BOT_SCRIPT_FILES);
-        assert.noFile(BOT_SCRIPT_TEST_FILES);
-        assert.file(BOT_FILES);
-        assert.file(BOT_HTML_FILES);
-    });
+      const npmRunBuildResult = await testHelper.runNpmCommand("npm run build", projectPath);
+      assert.equal(false, npmRunBuildResult);
+    }
+  });
 });

--- a/tests/ConnectorGenerator.spec.ts
+++ b/tests/ConnectorGenerator.spec.ts
@@ -1,13 +1,11 @@
-import * as path from 'path';
 import * as del from 'del';
-import * as fs from 'fs-extra';
 import * as helpers from 'yeoman-test';
 import * as assert from 'yeoman-assert';
 import { describe, it} from 'mocha';
 
 import * as testHelper from './helpers/TestHelper';
 
-describe('unit tests - teams:connector', function () {
+describe('teams:connector', function () {
 
     const CONNECTOR_HTML_FILES = [
         'src/app/web/connectortest01Connector/config.html'
@@ -30,8 +28,10 @@ describe('unit tests - teams:connector', function () {
     });
     
     it('should generate connector project with v1.3 with unit tests', async () => {
+        const projectPath = testHelper.TEMP_CONNECTOR_GENERATOR_PATH + "/connector-v13-withUnitT";
+
         await helpers.run(testHelper.GENERATOR_PATH)
-            .inDir(testHelper.TEMP_CONNECTOR_GENERATOR_PATH + '/connector01')
+            .inDir(projectPath)
             .withArguments(['--no-telemetry'])
             .withPrompts({
                 solutionName: 'connector-test-01',
@@ -56,11 +56,24 @@ describe('unit tests - teams:connector', function () {
         assert.file(CONNECTOR_SCRIPT_TEST_FILES);
         assert.file(CONNECTOR_FILES);
         assert.file(CONNECTOR_HTML_FILES);
+
+        if (process.env.TEST_TYPE == testHelper.TestTypes.INTEGRATION) {
+            const npmInstallResult = await testHelper.runNpmCommand("npm install", projectPath);
+            assert.equal(false, npmInstallResult);
+      
+            const npmRunBuildResult = await testHelper.runNpmCommand("npm run build", projectPath);
+            assert.equal(false, npmRunBuildResult);
+      
+            const npmRunTestResult = await testHelper.runNpmCommand("npm run test", projectPath);
+            assert.equal(false, npmRunTestResult);
+        }
     });
 
     it('should generate connector project with v1.3 without unit tests', async () => {
+        const projectPath = testHelper.TEMP_CONNECTOR_GENERATOR_PATH + "/connector-v13-withoutUnitT";
+
         await helpers.run(testHelper.GENERATOR_PATH)
-            .inDir(testHelper.TEMP_CONNECTOR_GENERATOR_PATH + '/connector02')
+            .inDir(projectPath)
             .withArguments(['--no-telemetry'])
             .withPrompts({
                 solutionName: 'connector-test-01',
@@ -85,11 +98,21 @@ describe('unit tests - teams:connector', function () {
         assert.noFile(CONNECTOR_SCRIPT_TEST_FILES);
         assert.file(CONNECTOR_FILES);
         assert.file(CONNECTOR_HTML_FILES);
+
+        if (process.env.TEST_TYPE == testHelper.TestTypes.INTEGRATION) {
+            const npmInstallResult = await testHelper.runNpmCommand("npm install", projectPath);
+            assert.equal(false, npmInstallResult);
+      
+            const npmRunBuildResult = await testHelper.runNpmCommand("npm run build", projectPath);
+            assert.equal(false, npmRunBuildResult);
+        }
     });
 
     it('should generate connector project with devPreview with unit tests', async () => {
+        const projectPath = testHelper.TEMP_CONNECTOR_GENERATOR_PATH + "/connector-dev-withUnitT";
+
         await helpers.run(testHelper.GENERATOR_PATH)
-            .inDir(testHelper.TEMP_CONNECTOR_GENERATOR_PATH + '/connector03')
+            .inDir(projectPath)
             .withArguments(['--no-telemetry'])
             .withPrompts({
                 solutionName: 'connector-test-01',
@@ -114,11 +137,24 @@ describe('unit tests - teams:connector', function () {
         assert.file(CONNECTOR_SCRIPT_TEST_FILES);
         assert.file(CONNECTOR_FILES);
         assert.file(CONNECTOR_HTML_FILES);
+
+        if (process.env.TEST_TYPE == testHelper.TestTypes.INTEGRATION) {
+            const npmInstallResult = await testHelper.runNpmCommand("npm install", projectPath);
+            assert.equal(false, npmInstallResult);
+      
+            const npmRunBuildResult = await testHelper.runNpmCommand("npm run build", projectPath);
+            assert.equal(false, npmRunBuildResult);
+      
+            const npmRunTestResult = await testHelper.runNpmCommand("npm run test", projectPath);
+            assert.equal(false, npmRunTestResult);
+        }
     });
 
     it('should generate connector project with devPreview without unit tests', async () => {
+        const projectPath = testHelper.TEMP_CONNECTOR_GENERATOR_PATH + "/connector-dev-withoutUnitT";
+
         await helpers.run(testHelper.GENERATOR_PATH)
-            .inDir(testHelper.TEMP_CONNECTOR_GENERATOR_PATH + '/connector04')
+            .inDir(projectPath)
             .withArguments(['--no-telemetry'])
             .withPrompts({
                 solutionName: 'connector-test-01',
@@ -143,5 +179,13 @@ describe('unit tests - teams:connector', function () {
         assert.noFile(CONNECTOR_SCRIPT_TEST_FILES);
         assert.file(CONNECTOR_FILES);
         assert.file(CONNECTOR_HTML_FILES);
+
+        if (process.env.TEST_TYPE == testHelper.TestTypes.INTEGRATION) {
+            const npmInstallResult = await testHelper.runNpmCommand("npm install", projectPath);
+            assert.equal(false, npmInstallResult);
+      
+            const npmRunBuildResult = await testHelper.runNpmCommand("npm run build", projectPath);
+            assert.equal(false, npmRunBuildResult);
+        }
     });
 });

--- a/tests/LocalizationGenerator.spec.ts
+++ b/tests/LocalizationGenerator.spec.ts
@@ -9,7 +9,7 @@ import { describe, it } from 'mocha';
 
 import * as testHelper from './helpers/TestHelper';
 
-describe('unit tests - teams:localization', function () {
+describe('teams:localization', function () {
 
 
     beforeEach(async () => {
@@ -17,8 +17,10 @@ describe('unit tests - teams:localization', function () {
     });
 
     it('should generate a v1.4 project without localizationInfo', async () => {
+        const projectPath = testHelper.TEMP_LOCALIZATION_GENERATOR_PATH + "/localization01-v14-withoutLocalization";
+
         await helpers.run(testHelper.GENERATOR_PATH)
-            .inDir(testHelper.TEMP_LOCALIZATION_GENERATOR_PATH + '/localization01')
+            .inDir(projectPath)
             .withArguments(['--no-telemetry'])
             .withPrompts({
                 solutionName: 'localization-test-01',
@@ -32,11 +34,20 @@ describe('unit tests - teams:localization', function () {
 
         assert.noJsonFileContent('src/manifest/manifest.json', { localizationInfo: {} });
 
+        if (process.env.TEST_TYPE == testHelper.TestTypes.INTEGRATION) {
+            const npmInstallResult = await testHelper.runNpmCommand("npm install", projectPath);
+            assert.equal(false, npmInstallResult);
+      
+            const npmRunBuildResult = await testHelper.runNpmCommand("npm run build", projectPath);
+            assert.equal(false, npmRunBuildResult);
+        }
     });
 
     it('should generate a v1.5 project with localizationInfo, using std setting for default language tag', async () => {
+        const projectPath = testHelper.TEMP_LOCALIZATION_GENERATOR_PATH + "/localization01-v14-withLocalization";
+
         await helpers.run(testHelper.GENERATOR_PATH)
-            .inDir(testHelper.TEMP_LOCALIZATION_GENERATOR_PATH + '/localization02')
+            .inDir(projectPath)
             .withArguments(['--no-telemetry'])
             .withPrompts({
                 solutionName: 'localization-test-02',
@@ -48,13 +59,23 @@ describe('unit tests - teams:localization', function () {
             })
             .withGenerators(testHelper.DEPENDENCIES);
 
-            assert.jsonFileContent('src/manifest/manifest.json', { localizationInfo: { defaultLanguageTag: "en-us" } });
+        assert.jsonFileContent('src/manifest/manifest.json', { localizationInfo: { defaultLanguageTag: "en-us" } });
+
+        if (process.env.TEST_TYPE == testHelper.TestTypes.INTEGRATION) {
+            const npmInstallResult = await testHelper.runNpmCommand("npm install", projectPath);
+            assert.equal(false, npmInstallResult);
+      
+            const npmRunBuildResult = await testHelper.runNpmCommand("npm run build", projectPath);
+            assert.equal(false, npmRunBuildResult);
+        }
 
     });
 
     it('should generate a v1.5 project with a default language tag', async () => {
+        const projectPath = testHelper.TEMP_LOCALIZATION_GENERATOR_PATH + "/localization01-v15-withLocalization";
+
         await helpers.run(testHelper.GENERATOR_PATH)
-            .inDir(testHelper.TEMP_LOCALIZATION_GENERATOR_PATH + '/localization03')
+            .inDir(projectPath)
             .withArguments(['--no-telemetry'])
             .withPrompts({
                 solutionName: 'localization-test-03',
@@ -70,11 +91,21 @@ describe('unit tests - teams:localization', function () {
 
         assert.jsonFileContent('src/manifest/manifest.json', { localizationInfo: { defaultLanguageTag: "en-us" } });
 
+        if (process.env.TEST_TYPE == testHelper.TestTypes.INTEGRATION) {
+            const npmInstallResult = await testHelper.runNpmCommand("npm install", projectPath);
+            assert.equal(false, npmInstallResult);
+      
+            const npmRunBuildResult = await testHelper.runNpmCommand("npm run build", projectPath);
+            assert.equal(false, npmRunBuildResult);
+        }
+
     });
 
     it('should generate a v1.5 project with a localization file', async () => {
+        const projectPath = testHelper.TEMP_LOCALIZATION_GENERATOR_PATH + "/localization01-v15-withLocFile";
+
         await helpers.run(testHelper.GENERATOR_PATH)
-            .inDir(testHelper.TEMP_LOCALIZATION_GENERATOR_PATH + '/localization04')
+            .inDir(projectPath)
             .withArguments(['--no-telemetry'])
             .withPrompts({
                 solutionName: 'localization-test-04',
@@ -108,11 +139,21 @@ describe('unit tests - teams:localization', function () {
             "description.short": "TODO: add short description here",
             "description.full": "TODO: add full description here"
         });
+
+        if (process.env.TEST_TYPE == testHelper.TestTypes.INTEGRATION) {
+            const npmInstallResult = await testHelper.runNpmCommand("npm install", projectPath);
+            assert.equal(false, npmInstallResult);
+      
+            const npmRunBuildResult = await testHelper.runNpmCommand("npm run build", projectPath);
+            assert.equal(false, npmRunBuildResult);
+        }
     });
 
     it('should generate a devPreview project with a localization file', async () => {
+        const projectPath = testHelper.TEMP_LOCALIZATION_GENERATOR_PATH + "/localization01-dev-withLocalization";
+
         await helpers.run(testHelper.GENERATOR_PATH)
-            .inDir(testHelper.TEMP_LOCALIZATION_GENERATOR_PATH + '/localization05')
+            .inDir(projectPath)
             .withArguments(['--no-telemetry'])
             .withPrompts({
                 solutionName: 'localization-test-05',
@@ -139,11 +180,21 @@ describe('unit tests - teams:localization', function () {
             }
         });
         assert.file('src/manifest/se-sv.json');
+
+        if (process.env.TEST_TYPE == testHelper.TestTypes.INTEGRATION) {
+            const npmInstallResult = await testHelper.runNpmCommand("npm install", projectPath);
+            assert.equal(false, npmInstallResult);
+      
+            const npmRunBuildResult = await testHelper.runNpmCommand("npm run build", projectPath);
+            assert.equal(false, npmRunBuildResult);
+        }
     });
 
     it('should generate a v1.5 project with a tab, and not add any localization info', async () => {
+        const projectPath = testHelper.TEMP_LOCALIZATION_GENERATOR_PATH + "/localization01-dev-withTab";
+
         await helpers.run(testHelper.GENERATOR_PATH)
-            .inDir(testHelper.TEMP_LOCALIZATION_GENERATOR_PATH + '/localization06')
+            .inDir(projectPath)
             .withArguments(['--no-telemetry'])
             .withPrompts({
                 solutionName: 'localization-test-06',
@@ -156,8 +207,15 @@ describe('unit tests - teams:localization', function () {
             })
             .withGenerators(testHelper.DEPENDENCIES);
 
-            assert.noJsonFileContent('src/manifest/manifest.json', { localizationInfo: { } });
+        assert.noJsonFileContent('src/manifest/manifest.json', { localizationInfo: { } });
 
+        if (process.env.TEST_TYPE == testHelper.TestTypes.INTEGRATION) {
+            const npmInstallResult = await testHelper.runNpmCommand("npm install", projectPath);
+            assert.equal(false, npmInstallResult);
+      
+            const npmRunBuildResult = await testHelper.runNpmCommand("npm run build", projectPath);
+            assert.equal(false, npmRunBuildResult);
+        }
     });
 
 });

--- a/tests/MessageExtensionGenerator.spec.ts
+++ b/tests/MessageExtensionGenerator.spec.ts
@@ -5,7 +5,7 @@ import { describe, it } from 'mocha';
 
 import * as testHelper from './helpers/TestHelper';
 
-describe('unit tests - teams:messageExtension', function () {
+describe('teams:messageExtension', function () {
 
     const MESSAGEEXTSION_HTML_FILES = [
         'src/app/web/messageExtensionTest01MessageExtension/config.html'
@@ -32,8 +32,10 @@ describe('unit tests - teams:messageExtension', function () {
     });
 
     it('should generate message extension project with v1.3 with unit tests', async () => {
+        const projectPath = testHelper.TEMP_MESSAGEEXTSION_GENERATOR_PATH + "/mesExt01-v13-withUnitT";
+
         await helpers.run(testHelper.GENERATOR_PATH)
-            .inDir(testHelper.TEMP_MESSAGEEXTSION_GENERATOR_PATH + '/messageExtension01')
+            .inDir(projectPath)
             .withArguments(['--no-telemetry'])
             .withPrompts({
                 solutionName: 'messageExtension-test-01',
@@ -62,11 +64,24 @@ describe('unit tests - teams:messageExtension', function () {
         assert.file(MESSAGEEXTSION_SCRIPT_TEST_FILES);
         assert.file(MESSAGEEXTSION_FILES);
         assert.file(MESSAGEEXTSION_HTML_FILES);
+
+        if (process.env.TEST_TYPE == testHelper.TestTypes.INTEGRATION) {
+            const npmInstallResult = await testHelper.runNpmCommand("npm install", projectPath);
+            assert.equal(false, npmInstallResult);
+      
+            const npmRunBuildResult = await testHelper.runNpmCommand("npm run build", projectPath);
+            assert.equal(false, npmRunBuildResult);
+      
+            const npmRunTestResult = await testHelper.runNpmCommand("npm run test", projectPath);
+            assert.equal(false, npmRunTestResult);
+        }
     });
 
     it('should generate message extension project with v1.4 with unit tests', async () => {
+        const projectPath = testHelper.TEMP_MESSAGEEXTSION_GENERATOR_PATH + "/mesExt01-v14-withUnitT";
+
         await helpers.run(testHelper.GENERATOR_PATH)
-            .inDir(testHelper.TEMP_MESSAGEEXTSION_GENERATOR_PATH + '/messageExtension01-1.4')
+            .inDir(projectPath)
             .withArguments(['--no-telemetry'])
             .withPrompts({
                 solutionName: 'messageExtension-test-01',
@@ -95,11 +110,24 @@ describe('unit tests - teams:messageExtension', function () {
         assert.file(MESSAGEEXTSION_SCRIPT_TEST_FILES);
         assert.file(MESSAGEEXTSION_FILES);
         assert.file(MESSAGEEXTSION_HTML_FILES);
+
+        if (process.env.TEST_TYPE == testHelper.TestTypes.INTEGRATION) {
+            const npmInstallResult = await testHelper.runNpmCommand("npm install", projectPath);
+            assert.equal(false, npmInstallResult);
+      
+            const npmRunBuildResult = await testHelper.runNpmCommand("npm run build", projectPath);
+            assert.equal(false, npmRunBuildResult);
+      
+            const npmRunTestResult = await testHelper.runNpmCommand("npm run test", projectPath);
+            assert.equal(false, npmRunTestResult);
+        }
     });
 
     it('should generate message extension project with v1.3 with unit tests, without configuration', async () => {
+        const projectPath = testHelper.TEMP_MESSAGEEXTSION_GENERATOR_PATH + "/mesExt01-v13-withUnitTwithoutConf";
+
         await helpers.run(testHelper.GENERATOR_PATH)
-            .inDir(testHelper.TEMP_MESSAGEEXTSION_GENERATOR_PATH + '/messageExtension01-noconfig')
+            .inDir(projectPath)
             .withArguments(['--no-telemetry'])
             .withPrompts({
                 solutionName: 'messageExtension-test-01',
@@ -129,10 +157,23 @@ describe('unit tests - teams:messageExtension', function () {
         assert.noFile(MESSAGEEXTSION_SCRIPT_TEST_FILES);
         assert.file(MESSAGEEXTSION_FILES);
         assert.noFile(MESSAGEEXTSION_HTML_FILES);
+
+        if (process.env.TEST_TYPE == testHelper.TestTypes.INTEGRATION) {
+            const npmInstallResult = await testHelper.runNpmCommand("npm install", projectPath);
+            assert.equal(false, npmInstallResult);
+      
+            const npmRunBuildResult = await testHelper.runNpmCommand("npm run build", projectPath);
+            assert.equal(false, npmRunBuildResult);
+      
+            const npmRunTestResult = await testHelper.runNpmCommand("npm run test", projectPath);
+            assert.equal(false, npmRunTestResult);
+        }
     });
     it('should generate message extension project with v1.4 with unit tests, without configuration', async () => {
+        const projectPath = testHelper.TEMP_MESSAGEEXTSION_GENERATOR_PATH + "/mesExt01-v14-withUnitTwithoutConf";
+
         await helpers.run(testHelper.GENERATOR_PATH)
-            .inDir(testHelper.TEMP_MESSAGEEXTSION_GENERATOR_PATH + '/messageExtension01-noconfig')
+            .inDir(projectPath)
             .withArguments(['--no-telemetry'])
             .withPrompts({
                 solutionName: 'messageExtension-test-01',
@@ -162,11 +203,24 @@ describe('unit tests - teams:messageExtension', function () {
         assert.noFile(MESSAGEEXTSION_SCRIPT_TEST_FILES);
         assert.file(MESSAGEEXTSION_FILES);
         assert.noFile(MESSAGEEXTSION_HTML_FILES);
+
+        if (process.env.TEST_TYPE == testHelper.TestTypes.INTEGRATION) {
+            const npmInstallResult = await testHelper.runNpmCommand("npm install", projectPath);
+            assert.equal(false, npmInstallResult);
+      
+            const npmRunBuildResult = await testHelper.runNpmCommand("npm run build", projectPath);
+            assert.equal(false, npmRunBuildResult);
+      
+            const npmRunTestResult = await testHelper.runNpmCommand("npm run test", projectPath);
+            assert.equal(false, npmRunTestResult);
+        }
     });
 
     it('should generate message extension project with v1.3 without unit tests', async () => {
+        const projectPath = testHelper.TEMP_MESSAGEEXTSION_GENERATOR_PATH + "/mesExt01-v13-withoutUnitT";
+
         await helpers.run(testHelper.GENERATOR_PATH)
-            .inDir(testHelper.TEMP_MESSAGEEXTSION_GENERATOR_PATH + '/messageExtension02')
+            .inDir(projectPath)
             .withArguments(['--no-telemetry'])
             .withPrompts({
                 solutionName: 'messageExtension-test-01',
@@ -195,11 +249,21 @@ describe('unit tests - teams:messageExtension', function () {
         assert.noFile(MESSAGEEXTSION_SCRIPT_TEST_FILES);
         assert.file(MESSAGEEXTSION_FILES);
         assert.file(MESSAGEEXTSION_HTML_FILES);
+
+        if (process.env.TEST_TYPE == testHelper.TestTypes.INTEGRATION) {
+            const npmInstallResult = await testHelper.runNpmCommand("npm install", projectPath);
+            assert.equal(false, npmInstallResult);
+      
+            const npmRunBuildResult = await testHelper.runNpmCommand("npm run build", projectPath);
+            assert.equal(false, npmRunBuildResult);
+        }
     });
 
     it('should generate message extension project with devPreview with unit tests', async () => {
+        const projectPath = testHelper.TEMP_MESSAGEEXTSION_GENERATOR_PATH + "/mesExt01-dev-withUnitT";
+
         await helpers.run(testHelper.GENERATOR_PATH)
-            .inDir(testHelper.TEMP_MESSAGEEXTSION_GENERATOR_PATH + '/messageExtension03')
+            .inDir(projectPath)
             .withArguments(['--no-telemetry'])
             .withPrompts({
                 solutionName: 'messageExtension-test-01',
@@ -228,11 +292,24 @@ describe('unit tests - teams:messageExtension', function () {
         assert.file(MESSAGEEXTSION_SCRIPT_TEST_FILES);
         assert.file(MESSAGEEXTSION_FILES);
         assert.file(MESSAGEEXTSION_HTML_FILES);
+
+        if (process.env.TEST_TYPE == testHelper.TestTypes.INTEGRATION) {
+            const npmInstallResult = await testHelper.runNpmCommand("npm install", projectPath);
+            assert.equal(false, npmInstallResult);
+      
+            const npmRunBuildResult = await testHelper.runNpmCommand("npm run build", projectPath);
+            assert.equal(false, npmRunBuildResult);
+      
+            const npmRunTestResult = await testHelper.runNpmCommand("npm run test", projectPath);
+            assert.equal(false, npmRunTestResult);
+        }
     });
 
     it('should generate message extension project with devPreview with unit tests, without configuration', async () => {
+        const projectPath = testHelper.TEMP_MESSAGEEXTSION_GENERATOR_PATH + "/mesExt01-dev-withUnitTwithoutConf";
+
         await helpers.run(testHelper.GENERATOR_PATH)
-            .inDir(testHelper.TEMP_MESSAGEEXTSION_GENERATOR_PATH + '/messageExtension03-noconfig')
+            .inDir(projectPath)
             .withArguments(['--no-telemetry'])
             .withPrompts({
                 solutionName: 'messageExtension-test-01',
@@ -262,11 +339,24 @@ describe('unit tests - teams:messageExtension', function () {
         assert.noFile(MESSAGEEXTSION_SCRIPT_TEST_FILES);
         assert.file(MESSAGEEXTSION_FILES);
         assert.noFile(MESSAGEEXTSION_HTML_FILES);
+
+        if (process.env.TEST_TYPE == testHelper.TestTypes.INTEGRATION) {
+            const npmInstallResult = await testHelper.runNpmCommand("npm install", projectPath);
+            assert.equal(false, npmInstallResult);
+      
+            const npmRunBuildResult = await testHelper.runNpmCommand("npm run build", projectPath);
+            assert.equal(false, npmRunBuildResult);
+      
+            const npmRunTestResult = await testHelper.runNpmCommand("npm run test", projectPath);
+            assert.equal(false, npmRunTestResult);
+        }
     });
 
     it('should generate message extension project with devPreview without unit tests', async () => {
+        const projectPath = testHelper.TEMP_MESSAGEEXTSION_GENERATOR_PATH + "/mesExt01-dev-withoutUnitT";
+
         await helpers.run(testHelper.GENERATOR_PATH)
-            .inDir(testHelper.TEMP_MESSAGEEXTSION_GENERATOR_PATH + '/messageExtension04')
+            .inDir(projectPath)
             .withArguments(['--no-telemetry'])
             .withPrompts({
                 solutionName: 'messageExtension-test-01',
@@ -295,11 +385,21 @@ describe('unit tests - teams:messageExtension', function () {
         assert.noFile(MESSAGEEXTSION_SCRIPT_TEST_FILES);
         assert.file(MESSAGEEXTSION_FILES);
         assert.file(MESSAGEEXTSION_HTML_FILES);
+
+        if (process.env.TEST_TYPE == testHelper.TestTypes.INTEGRATION) {
+            const npmInstallResult = await testHelper.runNpmCommand("npm install", projectPath);
+            assert.equal(false, npmInstallResult);
+      
+            const npmRunBuildResult = await testHelper.runNpmCommand("npm run build", projectPath);
+            assert.equal(false, npmRunBuildResult);
+        }
     });
 
     it('should generate a query message extension project with devPreview', async () => {
+        const projectPath = testHelper.TEMP_MESSAGEEXTSION_GENERATOR_PATH + "/mesExt01-dev-queryMessage";
+
         await helpers.run(testHelper.GENERATOR_PATH)
-            .inDir(testHelper.TEMP_MESSAGEEXTSION_GENERATOR_PATH + '/messageExtension05')
+            .inDir(projectPath)
             .withArguments(['--no-telemetry'])
             .withPrompts({
                 solutionName: 'messageExtension-test-01',
@@ -320,11 +420,21 @@ describe('unit tests - teams:messageExtension', function () {
 
         assert.fileContent('src/manifest/manifest.json', `"type": "query"`);
         assert.fileContent(MESSAGEEXTSION_FILES[0], "public async onQuery(");
+
+        if (process.env.TEST_TYPE == testHelper.TestTypes.INTEGRATION) {
+            const npmInstallResult = await testHelper.runNpmCommand("npm install", projectPath);
+            assert.equal(false, npmInstallResult);
+      
+            const npmRunBuildResult = await testHelper.runNpmCommand("npm run build", projectPath);
+            assert.equal(false, npmRunBuildResult);
+        }
     });
 
     it('should generate an action message (static with adaptiveCard response) extension project with 1.4', async () => {
+        const projectPath = testHelper.TEMP_MESSAGEEXTSION_GENERATOR_PATH + "/mesExt01-v14-withAdapCard";
+
         await helpers.run(testHelper.GENERATOR_PATH)
-            .inDir(testHelper.TEMP_MESSAGEEXTSION_GENERATOR_PATH + '/messageExtension06-1.4')
+            .inDir(projectPath)
             .withArguments(['--no-telemetry'])
             .withPrompts({
                 solutionName: 'messageExtension-test-01',
@@ -350,11 +460,21 @@ describe('unit tests - teams:messageExtension', function () {
         assert.jsonFileContent('src/manifest/manifest.json', { composeExtensions: [{ commands: [{ parameters: {} }] }] });
         assert.noFileContent(MESSAGEEXTSION_FILES[0], "public async onFetchTask(");
         assert.fileContent(MESSAGEEXTSION_FILES[0], "public async onSubmitAction(");
+
+        if (process.env.TEST_TYPE == testHelper.TestTypes.INTEGRATION) {
+            const npmInstallResult = await testHelper.runNpmCommand("npm install", projectPath);
+            assert.equal(false, npmInstallResult);
+      
+            const npmRunBuildResult = await testHelper.runNpmCommand("npm run build", projectPath);
+            assert.equal(false, npmRunBuildResult);
+        }
     });
 
     it('should generate an action message (static with adaptiveCard response) extension project with devPreview', async () => {
+        const projectPath = testHelper.TEMP_MESSAGEEXTSION_GENERATOR_PATH + "/mesExt01-dev-withAdapCard";
+
         await helpers.run(testHelper.GENERATOR_PATH)
-            .inDir(testHelper.TEMP_MESSAGEEXTSION_GENERATOR_PATH + '/messageExtension06')
+            .inDir(projectPath)
             .withArguments(['--no-telemetry'])
             .withPrompts({
                 solutionName: 'messageExtension-test-01',
@@ -382,11 +502,21 @@ describe('unit tests - teams:messageExtension', function () {
         assert.jsonFileContent('src/manifest/manifest.json', { composeExtensions: [{ commands: [{ context: ["compose", "commandBox"] }] }] });
         assert.noFileContent(MESSAGEEXTSION_FILES[0], "public async onFetchTask(");
         assert.fileContent(MESSAGEEXTSION_FILES[0], "public async onSubmitAction(");
+
+        if (process.env.TEST_TYPE == testHelper.TestTypes.INTEGRATION) {
+            const npmInstallResult = await testHelper.runNpmCommand("npm install", projectPath);
+            assert.equal(false, npmInstallResult);
+      
+            const npmRunBuildResult = await testHelper.runNpmCommand("npm run build", projectPath);
+            assert.equal(false, npmRunBuildResult);
+        }
     });
 
     it('should generate an action message (adaptiveCard with adaptiveCard response) extension project with devPreview', async () => {
+        const projectPath = testHelper.TEMP_MESSAGEEXTSION_GENERATOR_PATH + "/mesExt01-dev-withAdapResp";
+
         await helpers.run(testHelper.GENERATOR_PATH)
-            .inDir(testHelper.TEMP_MESSAGEEXTSION_GENERATOR_PATH + '/messageExtension07')
+            .inDir(projectPath)
             .withArguments(['--no-telemetry'])
             .withPrompts({
                 solutionName: 'messageExtension-test-01',
@@ -413,11 +543,20 @@ describe('unit tests - teams:messageExtension', function () {
         assert.fileContent(MESSAGEEXTSION_FILES[0], "public async onFetchTask(");
         assert.fileContent(MESSAGEEXTSION_FILES[0], "public async onSubmitAction(");
 
+        if (process.env.TEST_TYPE == testHelper.TestTypes.INTEGRATION) {
+            const npmInstallResult = await testHelper.runNpmCommand("npm install", projectPath);
+            assert.equal(false, npmInstallResult);
+      
+            const npmRunBuildResult = await testHelper.runNpmCommand("npm run build", projectPath);
+            assert.equal(false, npmRunBuildResult);
+        }
     });
 
     it('should generate an action message (taskModule with adaptive card response) extension project with devPreview', async () => {
+        const projectPath = testHelper.TEMP_MESSAGEEXTSION_GENERATOR_PATH + "/mesExt01-v13-withTaskModule";
+
         await helpers.run(testHelper.GENERATOR_PATH)
-            .inDir(testHelper.TEMP_MESSAGEEXTSION_GENERATOR_PATH + '/messageExtension08')
+            .inDir(projectPath)
             .withArguments(['--no-telemetry'])
             .withPrompts({
                 solutionName: 'messageExtension-test-01',
@@ -445,8 +584,13 @@ describe('unit tests - teams:messageExtension', function () {
         assert.fileContent(MESSAGEEXTSION_FILES[0], "public async onFetchTask(");
         assert.fileContent(MESSAGEEXTSION_FILES[0], "public async onSubmitAction(");
         assert.fileContent(MESSAGEEXTSION_FILES[0], "type: \"result\"");
-    });
-    
 
-    
+        if (process.env.TEST_TYPE == testHelper.TestTypes.INTEGRATION) {
+            const npmInstallResult = await testHelper.runNpmCommand("npm install", projectPath);
+            assert.equal(false, npmInstallResult);
+      
+            const npmRunBuildResult = await testHelper.runNpmCommand("npm run build", projectPath);
+            assert.equal(false, npmRunBuildResult);
+        }
+    });
 });

--- a/tests/helpers/TestHelper.ts
+++ b/tests/helpers/TestHelper.ts
@@ -77,3 +77,8 @@ export const SCHEMA_13 = 'https://developer.microsoft.com/en-us/json-schemas/tea
 export const SCHEMA_14 = 'https://developer.microsoft.com/en-us/json-schemas/teams/v1.4/MicrosoftTeams.schema.json';
 export const SCHEMA_15 = 'https://developer.microsoft.com/en-us/json-schemas/teams/v1.5/MicrosoftTeams.schema.json';
 export const SCHEMA_DEVPREVIEW = 'https://raw.githubusercontent.com/OfficeDev/microsoft-teams-app-schema/preview/DevPreview/MicrosoftTeams.schema.json';
+
+export enum TestTypes {
+    UNIT = "UNIT",
+    INTEGRATION = "INTEGRATION"
+}

--- a/tests/tabGenerator.spec.ts
+++ b/tests/tabGenerator.spec.ts
@@ -1,108 +1,51 @@
-import * as path from "path";
 import * as del from "del";
-import * as fs from "fs-extra";
 import * as helpers from "yeoman-test";
 import * as assert from "yeoman-assert";
 import { describe, it } from "mocha";
 
 import * as testHelper from "./helpers/TestHelper";
 
-const TAB_HTML_FILES = [
+describe("teams:tab", function() {
+  const TAB_HTML_FILES = [
     "src/app/web/tabtest01Tab/index.html",
     "src/app/web/tabtest01Tab/config.html",
     "src/app/web/tabtest01Tab/remove.html"
-];
+  ];
 
-const TAB_SCRIPT_FILES = [
+  const TAB_SCRIPT_FILES = [
     "src/app/scripts/tabtest01Tab/Tabtest01Tab.tsx",
     "src/app/scripts/tabtest01Tab/Tabtest01TabConfig.tsx",
     "src/app/scripts/tabtest01Tab/Tabtest01TabRemove.tsx"
-];
+  ];
 
-const TAB_SCRIPT_TEST_FILES = [
+  const TAB_SCRIPT_TEST_FILES = [
     "src/app/scripts/tabtest01Tab/__tests__/Tabtest01Tab.spec.tsx",
     "src/app/scripts/tabtest01Tab/__tests__/Tabtest01TabConfig.spec.tsx",
     "src/app/scripts/tabtest01Tab/__tests__/Tabtest01TabRemove.spec.tsx"
-];
+  ];
 
-const TAB_HTML_FILES_STATIC = ["src/app/web/tabtest01Tab/index.html"];
+  const TAB_HTML_FILES_STATIC = ["src/app/web/tabtest01Tab/index.html"];
 
-const TAB_SCRIPT_FILES_STATIC = [
+  const TAB_SCRIPT_FILES_STATIC = [
     "src/app/scripts/tabtest01Tab/Tabtest01Tab.tsx"
-];
+  ];
 
-const TAB_SCRIPT_TEST_FILES_STATIC = [
+  const TAB_SCRIPT_TEST_FILES_STATIC = [
     "src/app/scripts/tabtest01Tab/__tests__/Tabtest01Tab.spec.tsx"
-];
+  ];
 
-const TAB_FILES = "src/app/tabtest01Tab/tabtest01Tab.ts";
+  const TAB_FILES = "src/app/tabtest01Tab/tabtest01Tab.ts";
 
-describe("integration tests - teams:tab", function() {
-  
-    beforeEach(async () => {
-      await del([testHelper.TEMP_GENERATOR_PATTERN]);
-    });
-  
-    it("should generate tab project with v1.3 with unit tests", async () => {
-      await helpers
-        .run(testHelper.GENERATOR_PATH)
-        .inDir(testHelper.TEMP_TAB_GENERATOR_PATH + "/tab01")
-        .withArguments(["--no-telemetry"])
-        .withPrompts({
-          solutionName: "tab-test-01",
-          whichFolder: "current",
-          name: "tabtest01",
-          developer: "generator teams developer",
-          manifestVersion: "v1.3",
-          parts: "tab",
-          unitTestsEnabled: true,
-          tabType: "configurable"
-        })
-        .withGenerators(testHelper.DEPENDENCIES);
-  
-      assert.file(testHelper.ROOT_FILES);
-      assert.file(testHelper.TEST_FILES);
-      assert.file(testHelper.APP_FILES);
-      assert.file(testHelper.SCRIPT_FILES);
-      assert.file(testHelper.WEB_FILES);
-      assert.file(testHelper.MANIFEST_FILES);
-  
-      assert.fileContent("src/manifest/manifest.json", testHelper.SCHEMA_13);
-  
-      assert.jsonFileContent("src/manifest/manifest.json", {
-        configurableTabs: [
-          {
-            canUpdateConfiguration: true
-          }
-        ]
-      });
-  
-      assert.file(TAB_HTML_FILES);
-      assert.file(TAB_FILES);
-      assert.file(TAB_SCRIPT_FILES);
-      assert.file(TAB_SCRIPT_TEST_FILES);
-
-      const projectPath = testHelper.TEMP_TAB_GENERATOR_PATH + "/tab01";
-
-      const npmInstallResult = await testHelper.runNpmCommand('npm install', projectPath);
-      assert.equal(false, npmInstallResult)
-
-      const npmRunBuildResult = await testHelper.runNpmCommand('npm run build', projectPath);
-      assert.equal(false, npmRunBuildResult)
-    });
-
-});
-
-describe("unit tests - teams:tab", function() {
-  
   beforeEach(async () => {
     await del([testHelper.TEMP_GENERATOR_PATTERN]);
   });
 
   it("should generate tab project with v1.3 with unit tests", async () => {
+    const projectPath = testHelper.TEMP_TAB_GENERATOR_PATH + "/tab01-v13-withUnitT";
+
     await helpers
       .run(testHelper.GENERATOR_PATH)
-      .inDir(testHelper.TEMP_TAB_GENERATOR_PATH + "/tab01")
+      .inDir(projectPath)
       .withArguments(["--no-telemetry"])
       .withPrompts({
         solutionName: "tab-test-01",
@@ -137,12 +80,25 @@ describe("unit tests - teams:tab", function() {
     assert.file(TAB_FILES);
     assert.file(TAB_SCRIPT_FILES);
     assert.file(TAB_SCRIPT_TEST_FILES);
+
+    if (process.env.TEST_TYPE == testHelper.TestTypes.INTEGRATION) {
+      const npmInstallResult = await testHelper.runNpmCommand("npm install", projectPath);
+      assert.equal(false, npmInstallResult);
+
+      const npmRunBuildResult = await testHelper.runNpmCommand("npm run build", projectPath);
+      assert.equal(false, npmRunBuildResult);
+
+      const npmRunTestResult = await testHelper.runNpmCommand("npm run test", projectPath);
+      assert.equal(false, npmRunTestResult);
+    }
   });
 
   it("should generate a static tab project with v1.3 with unit tests", async () => {
+    const projectPath = testHelper.TEMP_TAB_GENERATOR_PATH + "/tab01-v13-withUnitTAndStatic";
+
     await helpers
       .run(testHelper.GENERATOR_PATH)
-      .inDir(testHelper.TEMP_TAB_GENERATOR_PATH + "/tab01")
+      .inDir(projectPath)
       .withArguments(["--no-telemetry"])
       .withPrompts({
         solutionName: "tab-test-01",
@@ -177,9 +133,22 @@ describe("unit tests - teams:tab", function() {
     assert.file(TAB_FILES);
     assert.file(TAB_SCRIPT_FILES_STATIC);
     assert.file(TAB_SCRIPT_TEST_FILES_STATIC);
+
+    if (process.env.TEST_TYPE == testHelper.TestTypes.INTEGRATION) {
+      const npmInstallResult = await testHelper.runNpmCommand("npm install", projectPath);
+      assert.equal(false, npmInstallResult);
+
+      const npmRunBuildResult = await testHelper.runNpmCommand("npm run build", projectPath);
+      assert.equal(false, npmRunBuildResult);
+
+      const npmRunTestResult = await testHelper.runNpmCommand("npm run test", projectPath);
+      assert.equal(false, npmRunTestResult);
+    }
   });
 
   it("should generate tab project with v1.3 without unit tests", async () => {
+    const projectPath = testHelper.TEMP_TAB_GENERATOR_PATH + "/tab01-v13-withoutUnitT";
+
     await helpers
       .run(testHelper.GENERATOR_PATH)
       .inDir(testHelper.TEMP_TAB_GENERATOR_PATH + "/tab02")
@@ -217,12 +186,22 @@ describe("unit tests - teams:tab", function() {
     assert.file(TAB_FILES);
     assert.file(TAB_SCRIPT_FILES);
     assert.noFile(TAB_SCRIPT_TEST_FILES);
+
+    if (process.env.TEST_TYPE == testHelper.TestTypes.INTEGRATION) {
+      const npmInstallResult = await testHelper.runNpmCommand("npm install", projectPath);
+      assert.equal(false, npmInstallResult);
+
+      const npmRunBuildResult = await testHelper.runNpmCommand("npm run build", projectPath);
+      assert.equal(false, npmRunBuildResult);
+    }
   });
 
   it("should generate a static tab project with v1.3 without unit tests", async () => {
+    const projectPath = testHelper.TEMP_TAB_GENERATOR_PATH + "/tab01-v13-withStaticwithoutUnitT";
+
     await helpers
       .run(testHelper.GENERATOR_PATH)
-      .inDir(testHelper.TEMP_TAB_GENERATOR_PATH + "/tab02")
+      .inDir(projectPath)
       .withArguments(["--no-telemetry"])
       .withPrompts({
         solutionName: "tab-test-01",
@@ -257,12 +236,99 @@ describe("unit tests - teams:tab", function() {
     assert.file(TAB_FILES);
     assert.file(TAB_SCRIPT_FILES_STATIC);
     assert.noFile(TAB_SCRIPT_TEST_FILES_STATIC);
+
+    if (process.env.TEST_TYPE == testHelper.TestTypes.INTEGRATION) {
+      const npmInstallResult = await testHelper.runNpmCommand("npm install", projectPath);
+      assert.equal(false, npmInstallResult);
+
+      const npmRunBuildResult = await testHelper.runNpmCommand("npm run build", projectPath);
+      assert.equal(false, npmRunBuildResult);
+    }
+  });
+
+  it("should generate tab project with v1.3 applicatiaon insights", async () => {
+    const projectPath = testHelper.TEMP_TAB_GENERATOR_PATH + "/tab01-v13-withAI";
+
+    await helpers
+      .run(testHelper.GENERATOR_PATH)
+      .inDir(projectPath)
+      .withArguments(["--no-telemetry"])
+      .withPrompts({
+        solutionName: "tab-test-01",
+        whichFolder: "current",
+        name: "tabtest01",
+        developer: "generator teams developer",
+        manifestVersion: "v1.3",
+        parts: "tab",
+        unitTestsEnabled: false,
+        useAzureAppInsights: true,
+        azureAppInsightsKey: "12341234-1234-1234-1234-123412341234",
+        tabType: "configurable"
+      })
+      .withGenerators(testHelper.DEPENDENCIES);
+
+    assert.fileContent(
+      ".env",
+      "APPINSIGHTS_INSTRUMENTATIONKEY=12341234-1234-1234-1234-123412341234"
+    );
+    assert.fileContent("package.json", `"applicationinsights": "^1.3.1"`);
+    assert.fileContent(
+      "src/app/web/index.html",
+      `var appInsights = window.appInsights`
+    );
+
+    if (process.env.TEST_TYPE == testHelper.TestTypes.INTEGRATION) {
+      const npmInstallResult = await testHelper.runNpmCommand("npm install", projectPath);
+      assert.equal(false, npmInstallResult);
+
+      const npmRunBuildResult = await testHelper.runNpmCommand("npm run build", projectPath);
+      assert.equal(false, npmRunBuildResult);
+    }
+  });
+
+  it("should generate tab project with v1.3 with noapplicatiaon insights", async () => {
+    const projectPath = testHelper.TEMP_TAB_GENERATOR_PATH + "/tab01-v13-withoutAI";
+
+    await helpers
+      .run(testHelper.GENERATOR_PATH)
+      .inDir(projectPath)
+      .withArguments(["--no-telemetry"])
+      .withPrompts({
+        solutionName: "tab-test-01",
+        whichFolder: "current",
+        name: "tabtest01",
+        developer: "generator teams developer",
+        manifestVersion: "v1.3",
+        parts: "tab",
+        unitTestsEnabled: false,
+        useAzureAppInsights: false,
+        tabType: "configurable"
+      })
+      .withGenerators(testHelper.DEPENDENCIES);
+
+    assert.fileContent(".env", "APPINSIGHTS_INSTRUMENTATIONKEY=");
+    assert.noFileContent("package.json", `"applicationinsights": "^1.3.1"`);
+    assert.noFileContent(
+      "src/app/web/index.html",
+      `var appInsights = window.appInsights`
+    );
+
+    if (process.env.TEST_TYPE == testHelper.TestTypes.INTEGRATION) {
+      const npmInstallResult = await testHelper.runNpmCommand("npm install", projectPath);
+      assert.equal(false, npmInstallResult);
+
+      const npmRunBuildResult = await testHelper.runNpmCommand("npm run build", projectPath);
+      assert.equal(false, npmRunBuildResult);
+    }
   });
 
   it("should generate tab project with v1.4 with unit tests", async () => {
+    const projectPath =
+      testHelper.TEMP_TAB_GENERATOR_PATH + "/tab01-v14-withUnitT";
+
     await helpers
       .run(testHelper.GENERATOR_PATH)
-      .inDir(testHelper.TEMP_TAB_GENERATOR_PATH + "/tab01-14")
+      .inDir(projectPath)
       .withArguments(["--no-telemetry"])
       .withPrompts({
         solutionName: "tab-test-01",
@@ -297,12 +363,25 @@ describe("unit tests - teams:tab", function() {
     assert.file(TAB_FILES);
     assert.file(TAB_SCRIPT_FILES);
     assert.file(TAB_SCRIPT_TEST_FILES);
+
+    if (process.env.TEST_TYPE == testHelper.TestTypes.INTEGRATION) {
+      const npmInstallResult = await testHelper.runNpmCommand("npm install", projectPath);
+      assert.equal(false, npmInstallResult);
+
+      const npmRunBuildResult = await testHelper.runNpmCommand("npm run build", projectPath);
+      assert.equal(false, npmRunBuildResult);
+
+      const npmRunTestResult = await testHelper.runNpmCommand("npm run test", projectPath);
+      assert.equal(false, npmRunTestResult);
+    }
   });
 
   it("should generate tab project with v1.4 without unit tests", async () => {
+    const projectPath = testHelper.TEMP_TAB_GENERATOR_PATH + "/tab01-v14-withoutUnitT";
+
     await helpers
       .run(testHelper.GENERATOR_PATH)
-      .inDir(testHelper.TEMP_TAB_GENERATOR_PATH + "/tab02-14")
+      .inDir(projectPath)
       .withArguments(["--no-telemetry"])
       .withPrompts({
         solutionName: "tab-test-01",
@@ -337,12 +416,22 @@ describe("unit tests - teams:tab", function() {
     assert.file(TAB_FILES);
     assert.file(TAB_SCRIPT_FILES);
     assert.noFile(TAB_SCRIPT_TEST_FILES);
+
+    if (process.env.TEST_TYPE == testHelper.TestTypes.INTEGRATION) {
+      const npmInstallResult = await testHelper.runNpmCommand("npm install", projectPath);
+      assert.equal(false, npmInstallResult);
+
+      const npmRunBuildResult = await testHelper.runNpmCommand("npm run build", projectPath);
+      assert.equal(false, npmRunBuildResult);
+    }
   });
 
   it("should generate a static tab project with v1.4 without unit tests", async () => {
+    const projectPath = testHelper.TEMP_TAB_GENERATOR_PATH + "/tab01-v14-withoutUnitTwithStatic";
+
     await helpers
       .run(testHelper.GENERATOR_PATH)
-      .inDir(testHelper.TEMP_TAB_GENERATOR_PATH + "/tab02-14")
+      .inDir(projectPath)
       .withArguments(["--no-telemetry"])
       .withPrompts({
         solutionName: "tab-test-01",
@@ -377,12 +466,22 @@ describe("unit tests - teams:tab", function() {
     assert.file(TAB_FILES);
     assert.file(TAB_SCRIPT_FILES_STATIC);
     assert.noFile(TAB_SCRIPT_TEST_FILES_STATIC);
+
+    if (process.env.TEST_TYPE == testHelper.TestTypes.INTEGRATION) {
+      const npmInstallResult = await testHelper.runNpmCommand("npm install", projectPath);
+      assert.equal(false, npmInstallResult);
+
+      const npmRunBuildResult = await testHelper.runNpmCommand("npm run build", projectPath);
+      assert.equal(false, npmRunBuildResult);
+    }
   });
 
   it("should generate tab project with v1.4 with SharePoint config", async () => {
+    const projectPath = testHelper.TEMP_TAB_GENERATOR_PATH + "/tab01-v14-withSP";
+
     await helpers
       .run(testHelper.GENERATOR_PATH)
-      .inDir(testHelper.TEMP_TAB_GENERATOR_PATH + "/tab02-14")
+      .inDir(projectPath)
       .withArguments(["--no-telemetry"])
       .withPrompts({
         solutionName: "tab-test-01",
@@ -420,12 +519,22 @@ describe("unit tests - teams:tab", function() {
     assert.file(TAB_FILES);
     assert.file(TAB_SCRIPT_FILES);
     assert.noFile(TAB_SCRIPT_TEST_FILES);
+
+    if (process.env.TEST_TYPE == testHelper.TestTypes.INTEGRATION) {
+      const npmInstallResult = await testHelper.runNpmCommand("npm install", projectPath);
+      assert.equal(false, npmInstallResult);
+
+      const npmRunBuildResult = await testHelper.runNpmCommand("npm run build", projectPath);
+      assert.equal(false, npmRunBuildResult);
+    }
   });
 
   it("should generate tab project with v1.5 without unit tests", async () => {
+    const projectPath = testHelper.TEMP_TAB_GENERATOR_PATH + "/tab01-v15-withoutUnitT";
+
     await helpers
       .run(testHelper.GENERATOR_PATH)
-      .inDir(testHelper.TEMP_TAB_GENERATOR_PATH + "/tab02-15")
+      .inDir(projectPath)
       .withArguments(["--no-telemetry"])
       .withPrompts({
         solutionName: "tab-test-01",
@@ -460,12 +569,22 @@ describe("unit tests - teams:tab", function() {
     assert.file(TAB_FILES);
     assert.file(TAB_SCRIPT_FILES);
     assert.noFile(TAB_SCRIPT_TEST_FILES);
+
+    if (process.env.TEST_TYPE == testHelper.TestTypes.INTEGRATION) {
+      const npmInstallResult = await testHelper.runNpmCommand("npm install", projectPath);
+      assert.equal(false, npmInstallResult);
+
+      const npmRunBuildResult = await testHelper.runNpmCommand("npm run build", projectPath);
+      assert.equal(false, npmRunBuildResult);
+    }
   });
 
   it("should generate tab project with v1.5 with SharePoint config", async () => {
+    const projectPath = testHelper.TEMP_TAB_GENERATOR_PATH + "/tab01-v15-withSP";
+
     await helpers
       .run(testHelper.GENERATOR_PATH)
-      .inDir(testHelper.TEMP_TAB_GENERATOR_PATH + "/tab02-15")
+      .inDir(projectPath)
       .withArguments(["--no-telemetry"])
       .withPrompts({
         solutionName: "tab-test-01",
@@ -503,12 +622,22 @@ describe("unit tests - teams:tab", function() {
     assert.file(TAB_FILES);
     assert.file(TAB_SCRIPT_FILES);
     assert.noFile(TAB_SCRIPT_TEST_FILES);
+
+    if (process.env.TEST_TYPE == testHelper.TestTypes.INTEGRATION) {
+      const npmInstallResult = await testHelper.runNpmCommand("npm install", projectPath);
+      assert.equal(false, npmInstallResult);
+
+      const npmRunBuildResult = await testHelper.runNpmCommand("npm run build", projectPath);
+      assert.equal(false, npmRunBuildResult);
+    }
   });
 
   it("should generate tab project with v1.5 with MPM Id", async () => {
+    const projectPath = testHelper.TEMP_TAB_GENERATOR_PATH + "/tab01-v15-withMPM";
+
     await helpers
       .run(testHelper.GENERATOR_PATH)
-      .inDir(testHelper.TEMP_TAB_GENERATOR_PATH + "/tab02-15-mpn")
+      .inDir(projectPath)
       .withArguments(["--no-telemetry"])
       .withPrompts({
         solutionName: "tab-test-01",
@@ -547,12 +676,132 @@ describe("unit tests - teams:tab", function() {
     assert.file(TAB_FILES);
     assert.file(TAB_SCRIPT_FILES);
     assert.noFile(TAB_SCRIPT_TEST_FILES);
+
+    if (process.env.TEST_TYPE == testHelper.TestTypes.INTEGRATION) {
+      const npmInstallResult = await testHelper.runNpmCommand("npm install", projectPath);
+      assert.equal(false, npmInstallResult);
+
+      const npmRunBuildResult = await testHelper.runNpmCommand("npm run build", projectPath);
+      assert.equal(false, npmRunBuildResult);
+    }
+  });
+
+  it("should generate tab project with v1.5 scoped to groupchat only", async () => {
+    const projectPath = testHelper.TEMP_TAB_GENERATOR_PATH + "/tab01-v15-GroupChat";
+
+    await helpers
+      .run(testHelper.GENERATOR_PATH)
+      .inDir(projectPath)
+      .withArguments(["--no-telemetry"])
+      .withPrompts({
+        solutionName: "tab-test-01",
+        whichFolder: "current",
+        name: "tabtest01",
+        developer: "generator teams developer",
+        manifestVersion: "v1.5",
+        parts: "tab",
+        tabScopes: ["groupchat"],
+        tabType: "configurable"
+      })
+      .withGenerators(testHelper.DEPENDENCIES);
+
+    assert.jsonFileContent("src/manifest/manifest.json", {
+      configurableTabs: [
+        {
+          scopes: ["groupchat"]
+        }
+      ]
+    });
+
+    if (process.env.TEST_TYPE == testHelper.TestTypes.INTEGRATION) {
+      const npmInstallResult = await testHelper.runNpmCommand("npm install", projectPath);
+      assert.equal(false, npmInstallResult);
+
+      const npmRunBuildResult = await testHelper.runNpmCommand("npm run build", projectPath);
+      assert.equal(false, npmRunBuildResult);
+    }
+  });
+
+  it("should generate tab project with v1.5 scoped to team only", async () => {
+    const projectPath =
+      testHelper.TEMP_TAB_GENERATOR_PATH + "/tab01-v15-TeamChat";
+
+    await helpers
+      .run(testHelper.GENERATOR_PATH)
+      .inDir(projectPath)
+      .withArguments(["--no-telemetry"])
+      .withPrompts({
+        solutionName: "tab-test-01",
+        whichFolder: "current",
+        name: "tabtest01",
+        developer: "generator teams developer",
+        manifestVersion: "v1.5",
+        parts: "tab",
+        tabScopes: ["team"],
+        tabType: "configurable"
+      })
+      .withGenerators(testHelper.DEPENDENCIES);
+
+    assert.jsonFileContent("src/manifest/manifest.json", {
+      configurableTabs: [
+        {
+          scopes: ["team"]
+        }
+      ]
+    });
+
+    if (process.env.TEST_TYPE == testHelper.TestTypes.INTEGRATION) {
+      const npmInstallResult = await testHelper.runNpmCommand("npm install", projectPath);
+      assert.equal(false, npmInstallResult);
+
+      const npmRunBuildResult = await testHelper.runNpmCommand("npm run build", projectPath);
+      assert.equal(false, npmRunBuildResult);
+    }
+  });
+
+  it("should generate tab project with v1.5 scoped to groupchat and team", async () => {
+    const projectPath =
+      testHelper.TEMP_TAB_GENERATOR_PATH + "/tab01-v15-GroupAndTeamChat";
+
+    await helpers
+      .run(testHelper.GENERATOR_PATH)
+      .inDir(projectPath)
+      .withArguments(["--no-telemetry"])
+      .withPrompts({
+        solutionName: "tab-test-01",
+        whichFolder: "current",
+        name: "tabtest01",
+        developer: "generator teams developer",
+        manifestVersion: "v1.5",
+        parts: "tab",
+        tabScopes: ["team", "groupchat"],
+        tabType: "configurable"
+      })
+      .withGenerators(testHelper.DEPENDENCIES);
+
+    assert.jsonFileContent("src/manifest/manifest.json", {
+      configurableTabs: [
+        {
+          scopes: ["team", "groupchat"]
+        }
+      ]
+    });
+
+    if (process.env.TEST_TYPE == testHelper.TestTypes.INTEGRATION) {
+      const npmInstallResult = await testHelper.runNpmCommand("npm install", projectPath);
+      assert.equal(false, npmInstallResult);
+
+      const npmRunBuildResult = await testHelper.runNpmCommand("npm run build", projectPath);
+      assert.equal(false, npmRunBuildResult);
+    }
   });
 
   it("should generate tab project with devPreview with unit tests", async () => {
+    const projectPath = testHelper.TEMP_TAB_GENERATOR_PATH + "/tab01-dev-withUnitT";
+
     await helpers
       .run(testHelper.GENERATOR_PATH)
-      .inDir(testHelper.TEMP_TAB_GENERATOR_PATH + "/tab03")
+      .inDir(projectPath)
       .withArguments(["--no-telemetry"])
       .withPrompts({
         solutionName: "tab-test-01",
@@ -590,12 +839,25 @@ describe("unit tests - teams:tab", function() {
     assert.file(TAB_FILES);
     assert.file(TAB_SCRIPT_FILES);
     assert.file(TAB_SCRIPT_TEST_FILES);
+
+    if (process.env.TEST_TYPE == testHelper.TestTypes.INTEGRATION) {
+      const npmInstallResult = await testHelper.runNpmCommand("npm install", projectPath);
+      assert.equal(false, npmInstallResult);
+
+      const npmRunBuildResult = await testHelper.runNpmCommand("npm run build", projectPath);
+      assert.equal(false, npmRunBuildResult);
+
+      const npmRunTestResult = await testHelper.runNpmCommand("npm run test", projectPath);
+      assert.equal(false, npmRunTestResult);
+    }
   });
 
   it("should generate tab project with devPreview without unit tests", async () => {
+    const projectPath = testHelper.TEMP_TAB_GENERATOR_PATH + "/tab01-dev-withoutUnitT";
+
     await helpers
       .run(testHelper.GENERATOR_PATH)
-      .inDir(testHelper.TEMP_TAB_GENERATOR_PATH + "/tab04")
+      .inDir(projectPath)
       .withArguments(["--no-telemetry"])
       .withPrompts({
         solutionName: "tab-test-01",
@@ -633,139 +895,13 @@ describe("unit tests - teams:tab", function() {
     assert.file(TAB_FILES);
     assert.file(TAB_SCRIPT_FILES);
     assert.noFile(TAB_SCRIPT_TEST_FILES);
-  });
 
-  it("should generate tab project applicatiaon insights", async () => {
-    await helpers
-      .run(testHelper.GENERATOR_PATH)
-      .inDir(testHelper.TEMP_TAB_GENERATOR_PATH + "/tab05")
-      .withArguments(["--no-telemetry"])
-      .withPrompts({
-        solutionName: "tab-test-01",
-        whichFolder: "current",
-        name: "tabtest01",
-        developer: "generator teams developer",
-        manifestVersion: "v1.3",
-        parts: "tab",
-        unitTestsEnabled: false,
-        useAzureAppInsights: true,
-        azureAppInsightsKey: "12341234-1234-1234-1234-123412341234",
-        tabType: "configurable"
-      })
-      .withGenerators(testHelper.DEPENDENCIES);
+    if (process.env.TEST_TYPE == testHelper.TestTypes.INTEGRATION) {
+      const npmInstallResult = await testHelper.runNpmCommand("npm install", projectPath);
+      assert.equal(false, npmInstallResult);
 
-    assert.fileContent(
-      ".env",
-      "APPINSIGHTS_INSTRUMENTATIONKEY=12341234-1234-1234-1234-123412341234"
-    );
-    assert.fileContent("package.json", `"applicationinsights": "^1.3.1"`);
-    assert.fileContent(
-      "src/app/web/index.html",
-      `var appInsights = window.appInsights`
-    );
-  });
-
-  it("should generate tab project with no applicatiaon insights", async () => {
-    await helpers
-      .run(testHelper.GENERATOR_PATH)
-      .inDir(testHelper.TEMP_TAB_GENERATOR_PATH + "/tab06")
-      .withArguments(["--no-telemetry"])
-      .withPrompts({
-        solutionName: "tab-test-01",
-        whichFolder: "current",
-        name: "tabtest01",
-        developer: "generator teams developer",
-        manifestVersion: "v1.3",
-        parts: "tab",
-        unitTestsEnabled: false,
-        useAzureAppInsights: false,
-        tabType: "configurable"
-      })
-      .withGenerators(testHelper.DEPENDENCIES);
-
-    assert.fileContent(".env", "APPINSIGHTS_INSTRUMENTATIONKEY=");
-    assert.noFileContent("package.json", `"applicationinsights": "^1.3.1"`);
-    assert.noFileContent(
-      "src/app/web/index.html",
-      `var appInsights = window.appInsights`
-    );
-  });
-
-  it("should generate tab project scoped to groupchat only", async () => {
-    await helpers
-      .run(testHelper.GENERATOR_PATH)
-      .inDir(testHelper.TEMP_TAB_GENERATOR_PATH + "/tab06")
-      .withArguments(["--no-telemetry"])
-      .withPrompts({
-        solutionName: "tab-test-01",
-        whichFolder: "current",
-        name: "tabtest01",
-        developer: "generator teams developer",
-        manifestVersion: "v1.5",
-        parts: "tab",
-        tabScopes: ["groupchat"],
-        tabType: "configurable"
-      })
-      .withGenerators(testHelper.DEPENDENCIES);
-
-    assert.jsonFileContent("src/manifest/manifest.json", {
-      configurableTabs: [
-        {
-          scopes: ["groupchat"]
-        }
-      ]
-    });
-  });
-
-  it("should generate tab project scoped to team only", async () => {
-    await helpers
-      .run(testHelper.GENERATOR_PATH)
-      .inDir(testHelper.TEMP_TAB_GENERATOR_PATH + "/tab06")
-      .withArguments(["--no-telemetry"])
-      .withPrompts({
-        solutionName: "tab-test-01",
-        whichFolder: "current",
-        name: "tabtest01",
-        developer: "generator teams developer",
-        manifestVersion: "v1.5",
-        parts: "tab",
-        tabScopes: ["team"],
-        tabType: "configurable"
-      })
-      .withGenerators(testHelper.DEPENDENCIES);
-
-    assert.jsonFileContent("src/manifest/manifest.json", {
-      configurableTabs: [
-        {
-          scopes: ["team"]
-        }
-      ]
-    });
-  });
-
-  it("should generate tab project scoped to groupchat and team", async () => {
-    await helpers
-      .run(testHelper.GENERATOR_PATH)
-      .inDir(testHelper.TEMP_TAB_GENERATOR_PATH + "/tab06")
-      .withArguments(["--no-telemetry"])
-      .withPrompts({
-        solutionName: "tab-test-01",
-        whichFolder: "current",
-        name: "tabtest01",
-        developer: "generator teams developer",
-        manifestVersion: "v1.5",
-        parts: "tab",
-        tabScopes: ["team", "groupchat"],
-        tabType: "configurable"
-      })
-      .withGenerators(testHelper.DEPENDENCIES);
-
-    assert.jsonFileContent("src/manifest/manifest.json", {
-      configurableTabs: [
-        {
-          scopes: ["team", "groupchat"]
-        }
-      ]
-    });
+      const npmRunBuildResult = await testHelper.runNpmCommand("npm run build", projectPath);
+      assert.equal(false, npmRunBuildResult);
+    }
   });
 });


### PR DESCRIPTION
Integration tests have been implemented. 

For running of integration tests: 
`npm run test-integration`

For running of unit tests:
`npm run test`

Advice:
The integration tests should be runned on build server because of storage consumption and duration.