### PR TITLE
Mintor typo fixes

### DIFF
--- a/src/app/GeneratorTeamsApp.ts
+++ b/src/app/GeneratorTeamsApp.ts
@@ -202,7 +202,7 @@ export class GeneratorTeamsApp extends Generator {
                 {
                     type: 'input',
                     name: 'mpnId',
-                    message: 'Enter your Microsoft Partner Id, if you have one? (Leave blank to skip)',
+                    message: 'Enter your Microsoft Partner ID, if you have one? (Leave blank to skip)',
                     default: undefined,
                     validate: (input: string) => {
                         return input.length <= 10;

--- a/src/app/GeneratorTeamsApp.ts
+++ b/src/app/GeneratorTeamsApp.ts
@@ -234,7 +234,7 @@ export class GeneratorTeamsApp extends Generator {
                             },
                         },
                         {
-                            name: 'A Bot',
+                            name: 'A bot',
                             disabled: this.options.existingManifest,
                             value: 'bot'
                         },

--- a/src/app/templates/.env
+++ b/src/app/templates/.env
@@ -1,7 +1,7 @@
 # The domain name of where you host your application
 HOSTNAME=<%=hostname%>
 
-# App Id and App Password ofr the Bot Framework bot
+# App Id and App Password for the Bot Framework bot
 <%= botidEnv %>=<%= botid ? botid : '' %>
 <%= botidEnvSecret %>=
 

--- a/src/app/templates/src/app/web/index.html
+++ b/src/app/templates/src/app/web/index.html
@@ -33,7 +33,7 @@
     <article class="l-article">
         <p><%= description %></p>
     <% if (botType == 'botframework') { %>
-        <p>Add the Bot to Microsoft Teams: 
+        <p>Add the bot to Microsoft Teams: 
             <a href='https://teams.microsoft.com/l/chat/0/0?users=28:{{<%= botidEnv %>}}'><img height="30" width="113" src='https://dev.botframework.com/Client/Images/Add-To-MSTeams-Buttons.png'></a></p>
     <% } %>
     </article>

--- a/src/bot/BotGenerator.ts
+++ b/src/bot/BotGenerator.ts
@@ -59,7 +59,7 @@ export class BotGenerator extends Generator {
                         type: 'input',
                         name: 'botid',
                         message: (answers) => {
-                            var message = 'I need the Microsoft App ID for the Bot. ';
+                            var message = 'What is the Microsoft App ID for the Bot? ';
                             if (answers.botTye == 'botframework') {
                                 message += 'If you don\'t specify a value now, you will need to manually edit it later. ';
                             }

--- a/src/bot/BotGenerator.ts
+++ b/src/bot/BotGenerator.ts
@@ -18,7 +18,7 @@ export class BotGenerator extends Generator {
         opts.force = true;
         this.options = opts.options === undefined ? new GeneratorTeamsAppOptions() : opts.options;
 
-        this.desc('Adds a Bot to a Teams project.');
+        this.desc('Adds a bot to a Teams project.');
     }
 
     public prompting() {
@@ -29,7 +29,7 @@ export class BotGenerator extends Generator {
                     {
                         type: 'list',
                         name: 'bottype',
-                        message: 'What type of Bot would you like to use?',
+                        message: 'What type of bot would you like to use?',
                         default: 'botframework',
                         choices: [
                             {
@@ -37,7 +37,7 @@ export class BotGenerator extends Generator {
                                 value: 'existing'
                             },
                             {
-                                name: 'A new Bot Framework bot',
+                                name: 'A new bot Framework bot',
                                 value: 'botframework'
                             }
                         ]
@@ -59,7 +59,7 @@ export class BotGenerator extends Generator {
                         type: 'input',
                         name: 'botid',
                         message: (answers) => {
-                            var message = 'What is the Microsoft App ID for the Bot? ';
+                            var message = 'What is the Microsoft App ID for the bot? ';
                             if (answers.botTye == 'botframework') {
                                 message += 'If you don\'t specify a value now, you will need to manually edit it later. ';
                             }
@@ -110,7 +110,7 @@ export class BotGenerator extends Generator {
                     {
                         type: 'confirm',
                         name: 'botCallingEnabled',
-                        message: 'Do you want to include Bot Calling support?',
+                        message: 'Do you want to include bot calling support?',
                         when: (answers: any) => {
                             return this.options.manifestVersion == "devPreview"; // Only available in devPreview for now
                         },

--- a/src/connector/ConnectorGenerator.ts
+++ b/src/connector/ConnectorGenerator.ts
@@ -48,7 +48,7 @@ export class ConnectorGenerator extends Generator {
                     {
                         type: 'input',
                         name: 'connectorId',
-                        message: 'What is the Id of your Connector (found in the Connector Developer Portal)?',
+                        message: 'What is the ID of your Connector (found in the Connector Developer Portal)?',
                         default: (answers: any) => {
                             return EmptyGuid.empty;
                         },

--- a/src/custombot/CustomBotGenerator.ts
+++ b/src/custombot/CustomBotGenerator.ts
@@ -23,7 +23,7 @@ export class CustomBotGenerator extends Generator {
                     {
                         type: 'input',
                         name: 'title',
-                        message: 'Name of your outgoing webhook?',
+                        message: 'What is the name of your outgoing webhook?',
                         default: this.options.title + ' Outgoing Webhook',
                         validate: (input) => {
                             if(! (/^[a-zA-Z].*/.test(input))) {

--- a/src/messageExtension/MessageExtensionGenerator.ts
+++ b/src/messageExtension/MessageExtensionGenerator.ts
@@ -30,7 +30,7 @@ export class MessageExtensionGenerator extends Generator {
                     {
                         type: 'list',
                         name: 'messageExtensionHost',
-                        message: 'Where is your message extension hosted ',
+                        message: 'Where is your message extension hosted?',
                         default: (answers: any) => {
                             if (this.options.botType == 'botframework') {
                                 return 'existing';
@@ -91,7 +91,7 @@ export class MessageExtensionGenerator extends Generator {
                         type: 'input',
                         name: 'messageExtensionId',
                         message: (answers: any) => {
-                            var message = 'I need the Microsoft App ID for the Bot used by the Message Extension. ';
+                            var message = 'What is the Microsoft App ID for the Bot used by the Message Extension? ';
                             return message;
                         },
                         default: (answers: any) => {

--- a/src/messageExtension/MessageExtensionGenerator.ts
+++ b/src/messageExtension/MessageExtensionGenerator.ts
@@ -107,7 +107,7 @@ export class MessageExtensionGenerator extends Generator {
                     {
                         type: 'list',
                         name: 'messagingExtensionType',
-                        message: 'What type of messaging extension command',
+                        message: 'What type of messaging extension command?',
                         choices: [
                             {
                                 name: "Search based messaging extension",
@@ -125,7 +125,7 @@ export class MessageExtensionGenerator extends Generator {
                     {
                         type: 'checkbox',
                         name: 'messagingExtensionActionContext',
-                        message: "What context do you want your action to work from",
+                        message: "What context do you want your action to work from?",
                         choices: [
                             {
                                 name: "The compose box",

--- a/src/messageExtension/MessageExtensionGenerator.ts
+++ b/src/messageExtension/MessageExtensionGenerator.ts
@@ -301,7 +301,7 @@ export class MessageExtensionGenerator extends Generator {
                                         if (idargval.startsWith("{") && idargval.endsWith("}")) {
                                             this.log(chalk.red("Please update your Bot ID references to use a Guids that are not encapsulated in { and }."))
                                         }
-                                        this.log(chalk.red('Unable to continue, as I cannot correlate the Bot Id and the TypeScript class'));
+                                        this.log(chalk.red('Unable to continue, as I cannot correlate the bot ID and the TypeScript class'));
                                         this.log(chalk.red('Please verify that you have a valid Guid or a valid environment variable in your BotDeclaration.'));
                                         process.exit(1);
                                     }

--- a/src/messageExtension/MessageExtensionGenerator.ts
+++ b/src/messageExtension/MessageExtensionGenerator.ts
@@ -44,17 +44,17 @@ export class MessageExtensionGenerator extends Generator {
                                 this.options.existingManifest && this.options.existingManifest.bots && this.options.existingManifest.bots.length > 0 ||
                                 this.options.existingManifest && this.options.existingManifest.composeExtensions && this.options.existingManifest.composeExtensions.length > 0) {
                                 choices.push({
-                                    name: 'In a Bot or Messaging Extension already defined in this project',
+                                    name: 'In a bot or Messaging Extension already defined in this project',
                                     value: 'existing',
                                 });
                             } else {
                                 choices.push({
-                                    name: 'In a new Bot',
+                                    name: 'In a new bot',
                                     value: 'new'
                                 });
                             }
                             choices.push({
-                                name: 'In a Bot hosted somewhere else',
+                                name: 'In a bot hosted somewhere else',
                                 value: 'external'
                             });
                             return choices;
@@ -68,7 +68,7 @@ export class MessageExtensionGenerator extends Generator {
                         choices: (answers: any) => {
                             let choices: any[] = [];
                             if (this.options.existingManifest.bots) {
-                                // TODO: use AST to find the Bot classes as well
+                                // TODO: use AST to find the bot classes as well
                                 // Check existing bots
                                 choices = this.options.existingManifest.bots.map((b: any) => {
                                     return b.botId;
@@ -91,7 +91,7 @@ export class MessageExtensionGenerator extends Generator {
                         type: 'input',
                         name: 'messageExtensionId',
                         message: (answers: any) => {
-                            var message = 'What is the Microsoft App ID for the Bot used by the Message Extension? ';
+                            var message = 'What is the Microsoft App ID for the bot used by the Message Extension? ';
                             return message;
                         },
                         default: (answers: any) => {
@@ -257,7 +257,7 @@ export class MessageExtensionGenerator extends Generator {
                 this.options.messageExtensionClassName = this.options.messageExtensionName.charAt(0).toUpperCase() + this.options.messageExtensionName.slice(1);
 
                 if (answers.messageExtensionHost == 'new') {
-                    // we need to add the Bot, even though the users did not choose to create one
+                    // we need to add the bot, even though the users did not choose to create one
                     this.options.messagingExtensionBot = true;
                     this.options.botid = answers.messageExtensionId;
                     this.options.messageExtensionId = `{{${this.options.botidEnv}}}`;
@@ -299,7 +299,7 @@ export class MessageExtensionGenerator extends Generator {
                                             return { c: c, id: `{{${idargval.substring(12)}}}` };
                                         }
                                         if (idargval.startsWith("{") && idargval.endsWith("}")) {
-                                            this.log(chalk.red("Please update your Bot ID references to use a Guids that are not encapsulated in { and }."))
+                                            this.log(chalk.red("Please update your bot ID references to use a Guids that are not encapsulated in { and }."))
                                         }
                                         this.log(chalk.red('Unable to continue, as I cannot correlate the bot ID and the TypeScript class'));
                                         this.log(chalk.red('Please verify that you have a valid Guid or a valid environment variable in your BotDeclaration.'));
@@ -320,7 +320,7 @@ export class MessageExtensionGenerator extends Generator {
                             // we need the directory here and not the actual bot name
                             this.options.botName = botClass.c.getSourceFile().getDirectory().getBaseName() as string;
                         } else {
-                            this.log(chalk.red('Unable to continue, as I could not locate the Bot implementation'));
+                            this.log(chalk.red('Unable to continue, as I could not locate the bot implementation'));
                             this.log(chalk.red('Please verify that you have a valid Guid or a valid environment variable in your BotDeclaration.'));
                             process.exit(1);
 
@@ -417,7 +417,7 @@ export class MessageExtensionGenerator extends Generator {
                     );
                 }
 
-                // Dynamically insert the reference and hook it up to the Bot
+                // Dynamically insert the reference and hook it up to the bot
                 const project = new Project();
                 const file = project.createSourceFile(
                     `src/app/${this.options.botName}/${this.options.botClassName}.ts`,


### PR DESCRIPTION
After refreshing the Teams Microsoft Learn modules for this quarter, I found a handful of minor typos & inconsistencies in the generator & generated files.

These changes are minor... nothing functional. They change things to match MSFT DOCS guidelines such as:
- Always use **ID**, not *id* or *Id*
- **bots** should always be lower case, unless when used in **Bot Framework**
- update prompts to match the question style used throughout, not statements/conversational style prompts

Also fixed minor typos