### PR TITLE
Updated AdaptiveCard schema to v1.2 from #101

### DIFF
--- a/src/bot/templates/src/app/{botName}/dialogs/WelcomeCard.json
+++ b/src/bot/templates/src/app/{botName}/dialogs/WelcomeCard.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
     "type": "AdaptiveCard",
-    "version": "1.0",
+    "version": "1.2",
     "body": [
       {
         "type": "TextBlock",

--- a/src/messageExtension/templates/src/app/{messageExtensionName}/{messageExtensionClassName}.ts
+++ b/src/messageExtension/templates/src/app/{messageExtensionName}/{messageExtensionClassName}.ts
@@ -40,7 +40,7 @@ const log = debug("msteams");
                     }
                 ],
                 $schema: "http://adaptivecards.io/schemas/adaptive-card.json",
-                version: "1.0"
+                version: "1.2"
             });
         const preview = {
             contentType: "application/vnd.microsoft.card.thumbnail",
@@ -136,7 +136,7 @@ const log = debug("msteams");
                 card: CardFactory.adaptiveCard({
                     $schema: "http://adaptivecards.io/schemas/adaptive-card.json",
                     type: "AdaptiveCard",
-                    version: "1.0",
+                    version: "1.2",
                     body: [
                         {
                             type: "TextBlock",
@@ -189,7 +189,7 @@ const log = debug("msteams");
                     }
                 ],
                 $schema: "http://adaptivecards.io/schemas/adaptive-card.json",
-                version: "1.0"
+                version: "1.2"
             });
         return Promise.resolve({
             type: "result",


### PR DESCRIPTION
According to the documentation and also the Adaptive Card Designer it is not necessary to change the schema URL. Therefore just bumping up the version to 1.2 shall be sufficient enough.