### PR TITLE
chore: update tsconfig-client.json to use ESM

### DIFF
--- a/src/app/templates/tsconfig-client.json
+++ b/src/app/templates/tsconfig-client.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "module": "commonjs",
+        "module": "es6",
         "target": "es5",
         "moduleResolution": "node",
         "noImplicitAny": false,


### PR DESCRIPTION
This PR updates `tsconfig-client.json` to target `module: es6` to enable tree-shaking properly, this also mentioned in official Webpack guide (https://webpack.js.org/guides/typescript/).

### `module: commonjs`
```js
"use strict";
Object.defineProperty(exports, "__esModule", { value: true });
const react_northstar_1 = require("@fluentui/react-northstar");
console.log(react_northstar_1.teamsTheme);
```

Output is **1.37 MiB** because [Module Concatenation](https://webpack.js.org/plugins/module-concatenation-plugin/) used for tree shaking in Webpack 4 does not work with Common JS.

### `module: es6`
```js
import { teamsTheme } from "@fluentui/react-northstar";
console.log(teamsTheme);
```

Output is **417 KiB**.