### PR TITLE
added HOSTNAME arg to Dockerfile

### DIFF
--- a/src/app/templates/Dockerfile
+++ b/src/app/templates/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:14 AS BUILD_IMAGE
 
+ARG HOSTNAME
+
 RUN curl -sfL https://install.goreleaser.com/github.com/tj/node-prune.sh | bash -s -- -b /usr/local/bin
 
 WORKDIR /app


### PR DESCRIPTION
The built docker image doesn't work for me if I don't add the ARG HOSTNAME to the Dockerfile. The reason is that webpack needs the process.env variable to be present when the build is executed.

The docker build command must also be executed with `--build-arg HOSTNAME=xxx.example.org` to inject the hostname.

The fact hat webpack hard-codes the hostname into the javascript bundles means that the docker containers aren't reusable and have to be built for every domain they run on - they can't be swapped between dev, staging and production...