### PR TITLE
Fixed typo in ngrok-serve task name

### DIFF
--- a/packages/yoteams-build-core/README.md
+++ b/packages/yoteams-build-core/README.md
@@ -31,7 +31,7 @@ The following Gulp tasks are defined by the package:
 * **`build`** - build the solution. Runs the following tasks in series: `webpack`, `styles`, `static:copy` and  `static:inject`
 * **`manifest`** - packages the manifest. The `validate-manifest` task is run as a part of this task
 * **`serve`** - builds and runs the solution on the local machine, background re-compilation when files are changed
-* **`serve-ngrok`** - builds and runs the solution on the local machine with ngrok support, see belo
+* **`ngrok-serve`** - builds and runs the solution on the local machine with ngrok support, see belo
 * **`webpack`** - runs webpack on the solution by running `webpack:client` and `webpack:server` in parallel
 * **`nuke`** - clears all build and temp files
 * **`static:copy`** - copies all static files to the dist folder

--- a/packages/yoteams-build-core/README.md
+++ b/packages/yoteams-build-core/README.md
@@ -2,7 +2,7 @@
 
 [![npm version](https://badge.fury.io/js/yoteams-build-core.svg)](https://www.npmjs.com/package/yoteams-build-core)
 [![npm](https://img.shields.io/npm/dt/yoteams-build-core.svg)](https://www.npmjs.com/package/yoteams-build-core)
-[![MIT](https://img.shields.io/npm/yoteams-build-core.svg)](https://github.com/PnP/generator-teams/blob/master/LICENSE.md)
+[![MIT](https://img.shields.io/npm/l/generator-teams.svg)](https://github.com/PnP/generator-teams/blob/master/LICENSE.md)
 
 Library with Gulp task for the Microsoft Teams Apps generator [**yo teams**](https://aka.ms/yoteams)
 

--- a/packages/yoteams-build-core/README.md
+++ b/packages/yoteams-build-core/README.md
@@ -31,7 +31,7 @@ The following Gulp tasks are defined by the package:
 * **`build`** - build the solution. Runs the following tasks in series: `webpack`, `styles`, `static:copy` and  `static:inject`
 * **`manifest`** - packages the manifest. The `validate-manifest` task is run as a part of this task
 * **`serve`** - builds and runs the solution on the local machine, background re-compilation when files are changed
-* **`ngrok-serve`** - builds and runs the solution on the local machine with ngrok support, see belo
+* **`ngrok-serve`** - builds and runs the solution on the local machine with ngrok support, see below
 * **`webpack`** - runs webpack on the solution by running `webpack:client` and `webpack:server` in parallel
 * **`nuke`** - clears all build and temp files
 * **`static:copy`** - copies all static files to the dist folder


### PR DESCRIPTION
I think there is a typo because the serve-ngrok task doesn't exist, while the ngrok-serve has always been there.
Even a small fix helps :-) ...