### PR TITLE
3.5.0-preview fixed some errors due to new bot classes

### DIFF
--- a/packages/generator-teams/src/bot/BotGenerator.ts
+++ b/packages/generator-teams/src/bot/BotGenerator.ts
@@ -187,7 +187,9 @@ export class BotGenerator extends Generator {
                 templateFiles.push(
                     "README-{botName}.md",
                     "src/server/{botName}/{botClassName}.ts",
-                    "src/server/{botName}/dialogBot.ts"
+                    "src/server/{botName}/dialogBot.ts",
+                    "src/server/{botName}/cards/welcomeCard.json",
+                    "src/server/{botName}/cards/welcomeCard.ts"  
                 );
                 // add additional files if we have a full bot implementation
                 if (this.options.bot) {
@@ -196,8 +198,6 @@ export class BotGenerator extends Generator {
                         "src/server/{botName}/dialogs/helpDialog.ts",
                         "src/server/{botName}/dialogs/mentionUserDialog.ts",
                         "src/server/{botName}/dialogs/teamsInfoDialog.ts",
-                        "src/server/{botName}/cards/welcomeCard.json",
-                        "src/server/{botName}/cards/welcomeCard.ts"                        
                     );
                     if (this.options.unitTestsEnabled) {
                         templateFiles.push(

--- a/packages/generator-teams/src/bot/templates/src/server/{botName}/{botClassName}.ts
+++ b/packages/generator-teams/src/bot/templates/src/server/{botName}/{botClassName}.ts
@@ -1,16 +1,11 @@
 import { BotDeclaration<% if (staticTab) { %>, PreventIframe<% } %><% if (botCallingEnabled) { %>, BotCallingWebhook<% } %> } from "express-msteams-host";
 import * as debug from "debug";
-import {
-    CardFactory,
-    ConversationState,
-    MemoryStorage,
-    UserState,
-    TurnContext
-} from "botbuilder";
-import { DialogBot } from "./dialogBot";
-import { MainDialog } from "./dialogs/mainDialog";
+import { <% if (messageExtension) { %>TeamsActivityHandler, StatePropertyAccessor, ActivityTypes,<% } %> CardFactory, ConversationState, MemoryStorage, <% if (bot) { %>UserState,<% } %> TurnContext } from "botbuilder";
+<% if (bot) { %>import { DialogBot } from "./dialogBot";
+import { MainDialog } from "./dialogs/mainDialog";<% } %>
 import WelcomeCard from "./cards/welcomeCard";
-
+<% if (botCallingEnabled) { %>import express = require("express");<% } %>
+<% if (messageExtension) { %>import { DialogSet, DialogState } from "botbuilder-dialogs";<% } %>
 // Initialize debug logging module
 const log = debug("msteams");
 
@@ -25,7 +20,7 @@ const log = debug("msteams");
       // eslint-disable-next-line no-undef
       process.env.<%= botidEnvSecret %>)
 <% if (staticTab) { %>@PreventIframe("/<%=botName%>/<%=staticTabName%>.html")<% } %>
-export class <%= botClassName %> extends DialogBot {
+<% if (bot) { %>export class <%= botClassName %> extends DialogBot {
     constructor(conversationState: ConversationState, userState: UserState) {
         super(conversationState, userState, new MainDialog());
 
@@ -41,7 +36,6 @@ export class <%= botClassName %> extends DialogBot {
             await next();
         });
     }
-
     public async sendWelcomeCard( context: TurnContext ): Promise<void> {
         const welcomeCard = CardFactory.adaptiveCard(WelcomeCard);
         await context.sendActivity({ attachments: [welcomeCard] });
@@ -58,4 +52,57 @@ export class <%= botClassName %> extends DialogBot {
         // default, send an access denied
         res.sendStatus(401);
     }<% } %>
-}
+}<% } %><% if (messageExtension && !bot) { %>export class <%= botClassName %> extends TeamsActivityHandler {
+        
+        private readonly conversationState: ConversationState;
+        private readonly dialogs: DialogSet;
+        private dialogState: StatePropertyAccessor<DialogState>;
+    
+        /**
+         * The constructor
+         * @param conversationState
+         */
+        public constructor(conversationState: ConversationState) {
+            super();
+    
+            this.conversationState = conversationState;
+            this.dialogState = conversationState.createProperty("dialogState");
+            this.dialogs = new DialogSet(this.dialogState);
+            // Set up the Activity processing
+            this.onMessage(async (context: TurnContext): Promise<void> => {
+                // TODO: add your own bot logic in here
+                switch (context.activity.type) {
+                    case ActivityTypes.Message:
+                        {
+                            let text = TurnContext.removeRecipientMention(context.activity);
+                            text = text.toLowerCase();
+                            if (text.startsWith("hello")) {
+                                await context.sendActivity("Oh, hello to you as well!");
+                                return;
+                            } else if (text.startsWith("help")) {
+                                await context.sendActivity("Please refer to [this link](https://docs.microsoft.com/en-us/microsoftteams/platform/bots/what-are-bots) to see how to develop bots for Teams");
+                            } else {
+                                await context.sendActivity("I'm terribly sorry, but my developer hasn't trained me to do anything yet...");
+                            }
+                        }
+                        break;
+                    default:
+                        break;
+                }
+                // Save state changes
+                return this.conversationState.saveChanges(context);
+            });
+    
+            this.onConversationUpdate(async (context: TurnContext): Promise<void> => {
+                if (context.activity.membersAdded && context.activity.membersAdded.length !== 0) {
+                    for (const idx in context.activity.membersAdded) {
+                        if (context.activity.membersAdded[idx].id === context.activity.recipient.id) {
+                            const welcomeCard = CardFactory.adaptiveCard(WelcomeCard);
+                            await context.sendActivity({ attachments: [welcomeCard] });
+                        }
+                    }
+                }
+            });
+        }
+    }
+<% } %>

--- a/packages/generator-teams/src/messageExtension/MessageExtensionGenerator.ts
+++ b/packages/generator-teams/src/messageExtension/MessageExtensionGenerator.ts
@@ -482,7 +482,9 @@ export class MessageExtensionGenerator extends Generator {
                         scope: Scope.Private,
                         name: `_${this.options.messageExtensionName}`,
                         type: this.options.messageExtensionClassName,
-                        docs: [`Local property for ${this.options.messageExtensionClassName}`]
+                        docs: [`Local property for ${this.options.messageExtensionClassName}`],
+                        trailingTrivia: writer => { writer.newLine(); writer.newLine(); }, // add a new line after the property to avoid eslint issue
+                        leadingTrivia: writer => writer.newLine(), // add a new line before the property to avoid eslint issue
                     });
 
                     // add the decorator
@@ -490,8 +492,6 @@ export class MessageExtensionGenerator extends Generator {
                         name: 'MessageExtensionDeclaration',
                         arguments: [`"${this.options.messageExtensionName}"`]
                     });
-                    // add a new line after the property to avoid eslint issue
-                    prop.appendWhitespace("\n");
 
                     const children = prop.getChildren();
                     if (children && children.length > 0) {


### PR DESCRIPTION
@wictorwilen I think I fixed all errors from the integration tests now. The only thing which I can't fix right now is a linting errors when scaffolding a bot+message extension as this line (494) in `MessageExtensionGenerator.ts` inserts not only 1 but two new blank lines, which leads to a linting issue:

`prop.appendWhitespace("\n");`

Any idea on this one?